### PR TITLE
Add Function for Installing Python Packages Using Pipx

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "tsc && jest"
   },
   "dependencies": {
-    "@actions/core": "^1.10.1"
+    "@actions/core": "^1.10.1",
+    "@actions/exec": "^1.1.1"
   },
   "devDependencies": {
     "@types/node": "^20.11.10",

--- a/src/pipx.mts
+++ b/src/pipx.mts
@@ -1,0 +1,5 @@
+import { exec } from "@actions/exec";
+
+export async function pipxInstall(pkg: string): Promise<void> {
+  await exec("pipx", ["install", pkg]);
+}

--- a/src/pipx.test.js
+++ b/src/pipx.test.js
@@ -1,0 +1,18 @@
+import { exec } from "@actions/exec";
+import { pipxInstall } from "./pipx.mjs";
+
+describe("install Python packages", () => {
+  beforeAll(async () => {
+    await exec("pipx", ["uninstall", "ruff"], { ignoreReturnCode: true });
+  });
+
+  it("should successfully install a package", async () => {
+    const prom = pipxInstall("ruff");
+    await expect(prom).resolves.toBeUndefined();
+  });
+
+  it("should fail to install an invalid package", async () => {
+    const prom = pipxInstall("invalid-pkg");
+    await expect(prom).rejects.toThrow();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@actions/exec@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@actions/exec@npm:1.1.1"
+  dependencies:
+    "@actions/io": "npm:^1.0.1"
+  checksum: 4a09f6bdbe50ce68b5cf8a7254d176230d6a74bccf6ecc3857feee209a8c950ba9adec87cc5ecceb04110182d1c17117234e45557d72fde6229b7fd3a395322a
+  languageName: node
+  linkType: hard
+
 "@actions/http-client@npm:^2.0.1":
   version: 2.2.0
   resolution: "@actions/http-client@npm:2.2.0"
@@ -29,6 +38,13 @@ __metadata:
     tunnel: "npm:^0.0.6"
     undici: "npm:^5.25.4"
   checksum: 868fe8529d78beb72f84ea2486e232fa6f66abe00d6ec4591b98c37e762c3d812868a3548638d75b49917961fd10ba1556916b47b1e9e4b55c266e2013c3ae8e
+  languageName: node
+  linkType: hard
+
+"@actions/io@npm:^1.0.1":
+  version: 1.1.3
+  resolution: "@actions/io@npm:1.1.3"
+  checksum: 5b8751918e5bf0bebd923ba917fb1c0e294401e7ff0037f32c92a4efa4215550df1f6633c63fd4efb2bdaae8711e69b9e36925857db1f38935ff62a5c92ec29e
   languageName: node
   linkType: hard
 
@@ -3962,6 +3978,7 @@ __metadata:
   resolution: "pipx-install-action@workspace:."
   dependencies:
     "@actions/core": "npm:^1.10.1"
+    "@actions/exec": "npm:^1.1.1"
     "@types/node": "npm:^20.11.10"
     "@typescript-eslint/eslint-plugin": "npm:^6.19.1"
     "@typescript-eslint/parser": "npm:^6.19.1"


### PR DESCRIPTION
This pull request resolves #5 by adding a `pipxInstall` function and its corresponding tests. The function is designed to invoke the `pipx install` command for installing Python packages using pipx.