### PR TITLE
Add Support to Install Multiple Packages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,9 @@
     "ecmaVersion": 2022,
     "sourceType": "module"
   },
+  "env": {
+    "es6": true
+  },
   "overrides": [
     {
       "files": ["**/*.mts", "**/*.ts"],

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,10 +65,10 @@ jobs:
             dist
           sparse-checkout-cone-mode: false
 
-      - name: Install Package
+      - name: Install Packages
         uses: ./pipx-install-action
         with:
-          packages: ruff
+          packages: black ruff
 
-      - name: Check Package
-        run: ruff --version
+      - name: Check Packages
+        run: black --version && ruff --version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Install Package
         uses: ./pipx-install-action
         with:
-          package: ruff
+          packages: ruff
 
       - name: Check Package
         run: ruff --version

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ If you are new to GitHub Actions, you can explore the [GitHub Actions guide](htt
 
 Here are the available input parameters for the Pipx Install Action:
 
-| Name      | Type                | Description                                 |
-| --------- | ------------------- | ------------------------------------------- |
-| `package` | `string` (required) | Name of the Python package to be installed. |
+| Name       | Type                       | Description                                   |
+| ---------- | -------------------------- | --------------------------------------------- |
+| `packages` | Multiple string (required) | Names of the Python packages to be installed. |
 
 ### Examples
 
@@ -45,7 +45,7 @@ jobs:
       - name: Install Ruff
         uses: threeal/pipx-install-action@main
         with:
-          package: ruff
+          packages: ruff
 
       # Add more steps as needed for your workflow
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -5,8 +5,8 @@ branding:
   icon: chevrons-right
   color: black
 inputs:
-  package:
-    description: Python package to be installed
+  packages:
+    description: Python packages to be installed
     required: true
 runs:
   using: node20

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -27251,8 +27251,10 @@ async function pipxInstall(...pkgs) {
 
 
 async function main() {
-    const pkg = core.getInput("package", { required: true });
-    await pipxInstall(pkg);
+    const pkgs = core.getInput("packages", { required: true })
+        .split(/(\s+)/)
+        .filter((pkg) => pkg.trim().length > 0);
+    await pipxInstall(...pkgs);
 }
 main().catch((err) => core.setFailed(err));
 

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -27243,8 +27243,8 @@ var core = __nccwpck_require__(4278);
 var exec = __nccwpck_require__(8434);
 ;// CONCATENATED MODULE: ./src/pipx.mjs
 
-async function pipxInstall(pkg) {
-    await (0,exec.exec)("pipx", ["install", pkg]);
+async function pipxInstall(...pkgs) {
+    await Promise.all(pkgs.map((pkg) => (0,exec.exec)("pipx", ["install", pkg])));
 }
 
 ;// CONCATENATED MODULE: ./src/index.mjs

--- a/src/index.mts
+++ b/src/index.mts
@@ -2,8 +2,12 @@ import core from "@actions/core";
 import { pipxInstall } from "./pipx.mjs";
 
 async function main() {
-  const pkg = core.getInput("package", { required: true });
-  await pipxInstall(pkg);
+  const pkgs = core
+    .getInput("packages", { required: true })
+    .split(/(\s+)/)
+    .filter((pkg) => pkg.trim().length > 0);
+
+  await pipxInstall(...pkgs);
 }
 
 main().catch((err) => core.setFailed(err));

--- a/src/pipx.mts
+++ b/src/pipx.mts
@@ -1,5 +1,5 @@
 import { exec } from "@actions/exec";
 
-export async function pipxInstall(pkg: string): Promise<void> {
-  await exec("pipx", ["install", pkg]);
+export async function pipxInstall(...pkgs: string[]): Promise<void> {
+  await Promise.all(pkgs.map((pkg) => exec("pipx", ["install", pkg])));
 }

--- a/src/pipx.test.js
+++ b/src/pipx.test.js
@@ -3,11 +3,14 @@ import { pipxInstall } from "./pipx.mjs";
 
 describe("install Python packages", () => {
   beforeAll(async () => {
-    await exec("pipx", ["uninstall", "ruff"], { ignoreReturnCode: true });
+    await Promise.all([
+      exec("pipx", ["install", "black"]),
+      exec("pipx", ["install", "ruff"]),
+    ]);
   });
 
-  it("should successfully install a package", async () => {
-    const prom = pipxInstall("ruff");
+  it("should successfully install packages", async () => {
+    const prom = pipxInstall("black", "ruff");
     await expect(prom).resolves.toBeUndefined();
   });
 


### PR DESCRIPTION
This pull request resolves #14 by introducing the following changes:
- Modifying the `pipxInstall` function to support the installation of multiple packages. This effectively changes the parameter to support variadic arguments and updates the testing.
- Modifying the action to support the installation of multiple packages. This effectively renames the action input to `packages` and updates the testing.