### PR TITLE
Use Mock in Pipx Installation Unit Test

### DIFF
--- a/src/pipx.test.js
+++ b/src/pipx.test.js
@@ -1,20 +1,43 @@
-import { exec } from "@actions/exec";
-import { pipxInstall } from "./pipx.mjs";
+import { jest } from "@jest/globals";
+
+let installedPkgs = [];
+
+jest.unstable_mockModule("@actions/exec", () => ({
+  exec: async (commandLine, args) => {
+    expect(commandLine).toBe("pipx");
+    expect(args.length).toBe(2);
+    expect(args[0]).toBe("install");
+
+    switch (args[1]) {
+      case "black":
+      case "ruff":
+        installedPkgs.push(args[1]);
+        break;
+
+      default:
+        throw new Error(`unknown package ${args[1]}`);
+    }
+  },
+}));
 
 describe("install Python packages", () => {
-  beforeAll(async () => {
-    await Promise.all([
-      exec("pipx", ["install", "black"]),
-      exec("pipx", ["install", "ruff"]),
-    ]);
+  beforeEach(() => {
+    installedPkgs = [];
   });
 
   it("should successfully install packages", async () => {
+    const { pipxInstall } = await import("./pipx.mjs");
+
     const prom = pipxInstall("black", "ruff");
     await expect(prom).resolves.toBeUndefined();
+
+    expect(installedPkgs).toContain("black");
+    expect(installedPkgs).toContain("ruff");
   });
 
   it("should fail to install an invalid package", async () => {
+    const { pipxInstall } = await import("./pipx.mjs");
+
     const prom = pipxInstall("invalid-pkg");
     await expect(prom).rejects.toThrow();
   });


### PR DESCRIPTION
This pull request resolves #9 by modifying the `pipx.test.js` file to use module mocking when testing the installation of Python packages.