### PR TITLE
Add Build Package Job in Build Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [main]
 jobs:
-  build-package:
-    name: Build Package
+  build-action:
+    name: Build Action
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,7 +20,7 @@ jobs:
       - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0
 
-      - name: Build Package
+      - name: Build Action
         run: |
           corepack yarn build
           git diff --exit-code HEAD

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,29 @@ on:
   push:
     branches: [main]
 jobs:
+  build-package:
+    name: Build Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.1
+        with:
+          node-version: 20
+
+      - name: Install Dependencies
+        uses: threeal/yarn-install-action@v1.0.0
+
+      - name: Build Package
+        run: corepack yarn pack
+
+      - name: Upload Package as Artifact
+        uses: actions/upload-artifact@v4.3.0
+        with:
+          path: package.tgz
+
   build-action:
     name: Build Action
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 node_modules/
 
 src/*.mjs
+package.tgz

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build": "tsc && ncc build src/main.mjs",
     "format": "prettier --write . !dist",
     "lint": "eslint --ignore-path .gitignore .",
+    "prepack": "tsc",
     "test": "tsc && jest"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request resolves #21 by introducing the following changes:
- Adds a `prepack` script for building JavaScript files before packaging.
- Renames the `build-package` job to `build-action`.
- Adds a new `build-package` job that is responsible for packaging.