### PR TITLE
Install Python Packages Sequentially

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -27244,7 +27244,9 @@ var exec = __nccwpck_require__(8434);
 ;// CONCATENATED MODULE: ./src/pipx.mjs
 
 async function pipxInstall(...pkgs) {
-    await Promise.all(pkgs.map((pkg) => (0,exec.exec)("pipx", ["install", pkg])));
+    for (const pkg of pkgs) {
+        await (0,exec.exec)("pipx", ["install", pkg]);
+    }
 }
 
 ;// CONCATENATED MODULE: ./src/main.mjs

--- a/src/pipx.mts
+++ b/src/pipx.mts
@@ -1,5 +1,7 @@
 import { exec } from "@actions/exec";
 
 export async function pipxInstall(...pkgs: string[]): Promise<void> {
-  await Promise.all(pkgs.map((pkg) => exec("pipx", ["install", pkg])));
+  for (const pkg of pkgs) {
+    await exec("pipx", ["install", pkg]);
+  }
 }


### PR DESCRIPTION
This pull request resolves #24 by modifying the `pipxInstall` function to install packages sequentially.