### PR TITLE
Modular Action Functions

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -27252,13 +27252,17 @@ async function installPackage(pkg) {
     }
 }
 
+;// CONCATENATED MODULE: ./src/pipx/index.mjs
+
+/* harmony default export */ const pipx = ({ installPackage: installPackage });
+
 ;// CONCATENATED MODULE: ./src/action.mjs
 
 
 async function pipxInstallAction(...pkgs) {
     for (const pkg of pkgs) {
         await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
-            await installPackage(pkg);
+            await pipx.installPackage(pkg);
         });
     }
 }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -27247,13 +27247,16 @@ var exec = __nccwpck_require__(8434);
 async function pipxInstall(...pkgs) {
     for (const pkg of pkgs) {
         await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
-            try {
-                await (0,exec.exec)("pipx", ["install", pkg]);
-            }
-            catch (err) {
-                throw new Error(`Failed to install ${pkg}: ${err.message}`);
-            }
+            await installPackage(pkg);
         });
+    }
+}
+async function installPackage(pkg) {
+    try {
+        await (0,exec.exec)("pipx", ["install", pkg]);
+    }
+    catch (err) {
+        throw new Error(`Failed to install ${pkg}: ${err.message}`);
     }
 }
 

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -27255,7 +27255,7 @@ async function installPackage(pkg) {
 ;// CONCATENATED MODULE: ./src/action.mjs
 
 
-async function pipxInstall(...pkgs) {
+async function pipxInstallAction(...pkgs) {
     for (const pkg of pkgs) {
         await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
             await installPackage(pkg);
@@ -27270,7 +27270,7 @@ async function main() {
     const pkgs = core.getInput("packages", { required: true })
         .split(/(\s+)/)
         .filter((pkg) => pkg.trim().length > 0);
-    await pipxInstall(...pkgs);
+    await pipxInstallAction(...pkgs);
 }
 main().catch((err) => core.setFailed(err));
 

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -27243,20 +27243,23 @@ var core = __nccwpck_require__(4278);
 var exec = __nccwpck_require__(8434);
 ;// CONCATENATED MODULE: ./src/pipx/install.mjs
 
-
-async function pipxInstall(...pkgs) {
-    for (const pkg of pkgs) {
-        await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
-            await installPackage(pkg);
-        });
-    }
-}
 async function installPackage(pkg) {
     try {
         await (0,exec.exec)("pipx", ["install", pkg]);
     }
     catch (err) {
         throw new Error(`Failed to install ${pkg}: ${err.message}`);
+    }
+}
+
+;// CONCATENATED MODULE: ./src/action.mjs
+
+
+async function pipxInstall(...pkgs) {
+    for (const pkg of pkgs) {
+        await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
+            await installPackage(pkg);
+        });
     }
 }
 

--- a/src/action.mts
+++ b/src/action.mts
@@ -1,0 +1,10 @@
+import core from "@actions/core";
+import { installPackage } from "./pipx/install.mjs";
+
+export async function pipxInstall(...pkgs: string[]): Promise<void> {
+  for (const pkg of pkgs) {
+    await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
+      await installPackage(pkg);
+    });
+  }
+}

--- a/src/action.mts
+++ b/src/action.mts
@@ -1,7 +1,7 @@
 import core from "@actions/core";
 import { installPackage } from "./pipx/install.mjs";
 
-export async function pipxInstall(...pkgs: string[]): Promise<void> {
+export async function pipxInstallAction(...pkgs: string[]): Promise<void> {
   for (const pkg of pkgs) {
     await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
       await installPackage(pkg);

--- a/src/action.mts
+++ b/src/action.mts
@@ -1,10 +1,10 @@
 import core from "@actions/core";
-import { installPackage } from "./pipx/install.mjs";
+import pipx from "./pipx/index.mjs";
 
 export async function pipxInstallAction(...pkgs: string[]): Promise<void> {
   for (const pkg of pkgs) {
     await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
-      await installPackage(pkg);
+      await pipx.installPackage(pkg);
     });
   }
 }

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -26,7 +26,7 @@ describe("install Python packages", () => {
   });
 
   it("should successfully install packages", async () => {
-    const { pipxInstall } = await import("./install.mjs");
+    const { pipxInstall } = await import("./action.mjs");
 
     const prom = pipxInstall("black", "ruff");
     await expect(prom).resolves.toBeUndefined();
@@ -36,7 +36,7 @@ describe("install Python packages", () => {
   });
 
   it("should fail to install an invalid package", async () => {
-    const { pipxInstall } = await import("./install.mjs");
+    const { pipxInstall } = await import("./action.mjs");
 
     const prom = pipxInstall("invalid-pkg");
     await expect(prom).rejects.toThrow("Failed to install invalid-pkg");

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -26,9 +26,9 @@ describe("install Python packages", () => {
   });
 
   it("should successfully install packages", async () => {
-    const { pipxInstall } = await import("./action.mjs");
+    const { pipxInstallAction } = await import("./action.mjs");
 
-    const prom = pipxInstall("black", "ruff");
+    const prom = pipxInstallAction("black", "ruff");
     await expect(prom).resolves.toBeUndefined();
 
     expect(installedPkgs).toContain("black");
@@ -36,9 +36,9 @@ describe("install Python packages", () => {
   });
 
   it("should fail to install an invalid package", async () => {
-    const { pipxInstall } = await import("./action.mjs");
+    const { pipxInstallAction } = await import("./action.mjs");
 
-    const prom = pipxInstall("invalid-pkg");
+    const prom = pipxInstallAction("invalid-pkg");
     await expect(prom).rejects.toThrow("Failed to install invalid-pkg");
   });
 });

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -2,25 +2,13 @@ import { jest } from "@jest/globals";
 
 let installedPkgs = [];
 
-jest.unstable_mockModule("@actions/exec", () => ({
-  exec: async (commandLine, args) => {
-    expect(commandLine).toBe("pipx");
-    expect(args.length).toBe(2);
-    expect(args[0]).toBe("install");
-
-    switch (args[1]) {
-      case "black":
-      case "ruff":
-        installedPkgs.push(args[1]);
-        break;
-
-      default:
-        throw new Error(`unknown package ${args[1]}`);
-    }
+jest.unstable_mockModule("./pipx/install.mjs", () => ({
+  installPackage: async (pkg) => {
+    installedPkgs.push(pkg);
   },
 }));
 
-describe("install Python packages", () => {
+describe("install Python packages action", () => {
   beforeEach(() => {
     installedPkgs = [];
   });
@@ -33,12 +21,5 @@ describe("install Python packages", () => {
 
     expect(installedPkgs).toContain("black");
     expect(installedPkgs).toContain("ruff");
-  });
-
-  it("should fail to install an invalid package", async () => {
-    const { pipxInstallAction } = await import("./action.mjs");
-
-    const prom = pipxInstallAction("invalid-pkg");
-    await expect(prom).rejects.toThrow("Failed to install invalid-pkg");
   });
 });

--- a/src/index.mts
+++ b/src/index.mts
@@ -1,1 +1,1 @@
-export { pipxInstall } from "./pipx/install.mjs";
+export { pipxInstall } from "./action.mjs";

--- a/src/index.mts
+++ b/src/index.mts
@@ -1,1 +1,1 @@
-export { pipxInstall } from "./action.mjs";
+export { pipxInstallAction } from "./action.mjs";

--- a/src/main.mts
+++ b/src/main.mts
@@ -1,5 +1,5 @@
 import core from "@actions/core";
-import { pipxInstall } from "./action.mjs";
+import { pipxInstallAction } from "./action.mjs";
 
 async function main() {
   const pkgs = core
@@ -7,7 +7,7 @@ async function main() {
     .split(/(\s+)/)
     .filter((pkg) => pkg.trim().length > 0);
 
-  await pipxInstall(...pkgs);
+  await pipxInstallAction(...pkgs);
 }
 
 main().catch((err) => core.setFailed(err));

--- a/src/main.mts
+++ b/src/main.mts
@@ -1,5 +1,5 @@
 import core from "@actions/core";
-import { pipxInstall } from "./pipx/install.mjs";
+import { pipxInstall } from "./action.mjs";
 
 async function main() {
   const pkgs = core

--- a/src/pipx/index.mts
+++ b/src/pipx/index.mts
@@ -1,0 +1,3 @@
+import { installPackage } from "./install.mjs";
+
+export default { installPackage };

--- a/src/pipx/install.mts
+++ b/src/pipx/install.mts
@@ -1,13 +1,4 @@
-import core from "@actions/core";
 import { exec } from "@actions/exec";
-
-export async function pipxInstall(...pkgs: string[]): Promise<void> {
-  for (const pkg of pkgs) {
-    await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
-      await installPackage(pkg);
-    });
-  }
-}
 
 export async function installPackage(pkg: string): Promise<void> {
   try {

--- a/src/pipx/install.mts
+++ b/src/pipx/install.mts
@@ -4,11 +4,15 @@ import { exec } from "@actions/exec";
 export async function pipxInstall(...pkgs: string[]): Promise<void> {
   for (const pkg of pkgs) {
     await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
-      try {
-        await exec("pipx", ["install", pkg]);
-      } catch (err) {
-        throw new Error(`Failed to install ${pkg}: ${(err as Error).message}`);
-      }
+      await installPackage(pkg);
     });
+  }
+}
+
+export async function installPackage(pkg: string): Promise<void> {
+  try {
+    await exec("pipx", ["install", pkg]);
+  } catch (err) {
+    throw new Error(`Failed to install ${pkg}: ${(err as Error).message}`);
   }
 }

--- a/src/pipx/install.test.js
+++ b/src/pipx/install.test.js
@@ -1,0 +1,42 @@
+import { jest } from "@jest/globals";
+
+let installedPkgs = [];
+
+jest.unstable_mockModule("@actions/exec", () => ({
+  exec: async (commandLine, args) => {
+    expect(commandLine).toBe("pipx");
+    expect(args.length).toBe(2);
+    expect(args[0]).toBe("install");
+
+    switch (args[1]) {
+      case "ruff":
+        installedPkgs.push(args[1]);
+        break;
+
+      default:
+        throw new Error("unknown package");
+    }
+  },
+}));
+
+describe("install Python packages", () => {
+  beforeEach(() => {
+    installedPkgs = [];
+  });
+
+  it("should successfully install a package", async () => {
+    const { installPackage } = await import("./install.mjs");
+
+    const prom = installPackage("ruff");
+    await expect(prom).resolves.toBeUndefined();
+
+    expect(installedPkgs).toContain("ruff");
+  });
+
+  it("should fail to install an invalid package", async () => {
+    const { installPackage } = await import("./install.mjs");
+
+    const prom = installPackage("invalid-pkg");
+    await expect(prom).rejects.toThrow("Failed to install invalid-pkg");
+  });
+});


### PR DESCRIPTION
This pull request resolves #31 by introducing the following changes:
- Separates the `pipxInstall` function into `pipxInstallAction` and `installPackages` functions.
- Puts the `pipxInstallAction` function in the `src/action.mts` file and the `installPackages` function in the `src/pipx/install.mts` file.
- Separates the `pipxInstall` function's testing to the `src/action.test.js` and `src/pipx/install.test.js` files.
- Adds a `src/pipx/index.mts` file.