### PR TITLE
Add Function for Getting Pipx Environment

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -27241,6 +27241,18 @@ var __webpack_exports__ = {};
 var core = __nccwpck_require__(4278);
 // EXTERNAL MODULE: ./.yarn/cache/@actions-exec-npm-1.1.1-90973d2f96-4a09f6bdbe.zip/node_modules/@actions/exec/lib/exec.js
 var exec = __nccwpck_require__(8434);
+;// CONCATENATED MODULE: ./src/pipx/environment.mjs
+
+async function getEnvironment(env) {
+    try {
+        const res = await (0,exec.getExecOutput)("pipx", ["environment", "--value", env]);
+        return res.stdout;
+    }
+    catch (err) {
+        throw new Error(`Failed to get ${env}: ${err.message}`);
+    }
+}
+
 ;// CONCATENATED MODULE: ./src/pipx/install.mjs
 
 async function installPackage(pkg) {
@@ -27254,7 +27266,8 @@ async function installPackage(pkg) {
 
 ;// CONCATENATED MODULE: ./src/pipx/index.mjs
 
-/* harmony default export */ const pipx = ({ installPackage: installPackage });
+
+/* harmony default export */ const pipx = ({ getEnvironment: getEnvironment, installPackage: installPackage });
 
 ;// CONCATENATED MODULE: ./src/action.mjs
 

--- a/src/pipx/environment.mts
+++ b/src/pipx/environment.mts
@@ -1,0 +1,10 @@
+import { getExecOutput } from "@actions/exec";
+
+export async function getEnvironment(env: string): Promise<string> {
+  try {
+    const res = await getExecOutput("pipx", ["environment", "--value", env]);
+    return res.stdout;
+  } catch (err) {
+    throw new Error(`Failed to get ${env}: ${(err as Error).message}`);
+  }
+}

--- a/src/pipx/environment.test.js
+++ b/src/pipx/environment.test.js
@@ -1,0 +1,34 @@
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule("@actions/exec", () => ({
+  getExecOutput: async (commandLine, args) => {
+    expect(commandLine).toBe("pipx");
+    expect(args.length).toBe(3);
+    expect(args[0]).toBe("environment");
+    expect(args[1]).toBe("--value");
+
+    switch (args[2]) {
+      case "PIPX_LOCAL_VENVS":
+        return { stdout: "/path/to/venvs" };
+
+      default:
+        throw new Error("unknown environment");
+    }
+  },
+}));
+
+describe("get pipx environments", () => {
+  it("should successfully get an environment", async () => {
+    const { getEnvironment } = await import("./environment.mjs");
+
+    const prom = getEnvironment("PIPX_LOCAL_VENVS");
+    await expect(prom).resolves.toBe("/path/to/venvs");
+  });
+
+  it("should fail to get an invalid environment", async () => {
+    const { getEnvironment } = await import("./environment.mjs");
+
+    const prom = getEnvironment("INVALID_ENV");
+    await expect(prom).rejects.toThrow("Failed to get INVALID_ENV");
+  });
+});

--- a/src/pipx/index.mts
+++ b/src/pipx/index.mts
@@ -1,3 +1,4 @@
+import { getEnvironment } from "./environment.mjs";
 import { installPackage } from "./install.mjs";
 
-export default { installPackage };
+export default { getEnvironment, installPackage };


### PR DESCRIPTION
This pull request resolves #28 by adding a `getEnvironment` function under the `src/pipx/environment.mts` file. It also introduces testing for that function in the `src/pipx/environment.test.js` file.