### PR TITLE
Add Cache Support

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -81512,12 +81512,17 @@ async function installPackage(pkg) {
 
 async function pipxInstallAction(...pkgs) {
     for (const pkg of pkgs) {
-        await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
-            await pipx.installPackage(pkg);
+        const cacheFound = await core.group(`Restoring \u001b[34m${pkg}\u001b[39m cache...`, async () => {
+            return pipx.restorePackageCache(pkg);
         });
-        await core.group(`Saving \u001b[34m${pkg}\u001b[39m cache...`, async () => {
-            await pipx.savePackageCache(pkg);
-        });
+        if (!cacheFound) {
+            await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
+                await pipx.installPackage(pkg);
+            });
+            await core.group(`Saving \u001b[34m${pkg}\u001b[39m cache...`, async () => {
+                await pipx.savePackageCache(pkg);
+            });
+        }
     }
 }
 

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -81515,6 +81515,9 @@ async function pipxInstallAction(...pkgs) {
         await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
             await pipx.installPackage(pkg);
         });
+        await core.group(`Saving \u001b[34m${pkg}\u001b[39m cache...`, async () => {
+            await pipx.savePackageCache(pkg);
+        });
     }
 }
 

--- a/src/action.mts
+++ b/src/action.mts
@@ -6,5 +6,9 @@ export async function pipxInstallAction(...pkgs: string[]): Promise<void> {
     await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
       await pipx.installPackage(pkg);
     });
+
+    await core.group(`Saving \u001b[34m${pkg}\u001b[39m cache...`, async () => {
+      await pipx.savePackageCache(pkg);
+    });
   }
 }

--- a/src/action.mts
+++ b/src/action.mts
@@ -3,12 +3,24 @@ import pipx from "./pipx/index.mjs";
 
 export async function pipxInstallAction(...pkgs: string[]): Promise<void> {
   for (const pkg of pkgs) {
-    await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
-      await pipx.installPackage(pkg);
-    });
+    const cacheFound = await core.group(
+      `Restoring \u001b[34m${pkg}\u001b[39m cache...`,
+      async () => {
+        return pipx.restorePackageCache(pkg);
+      },
+    );
 
-    await core.group(`Saving \u001b[34m${pkg}\u001b[39m cache...`, async () => {
-      await pipx.savePackageCache(pkg);
-    });
+    if (!cacheFound) {
+      await core.group(`Installing \u001b[34m${pkg}\u001b[39m...`, async () => {
+        await pipx.installPackage(pkg);
+      });
+
+      await core.group(
+        `Saving \u001b[34m${pkg}\u001b[39m cache...`,
+        async () => {
+          await pipx.savePackageCache(pkg);
+        },
+      );
+    }
   }
 }

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -1,16 +1,23 @@
 import { jest } from "@jest/globals";
 
 let installedPkgs = [];
+let savedPkgsCaches = [];
 
-jest.unstable_mockModule("./pipx/install.mjs", () => ({
-  installPackage: async (pkg) => {
-    installedPkgs.push(pkg);
+jest.unstable_mockModule("./pipx/index.mjs", () => ({
+  default: {
+    installPackage: async (pkg) => {
+      installedPkgs.push(pkg);
+    },
+    savePackageCache: async (pkg) => {
+      savedPkgsCaches.push(pkg);
+    },
   },
 }));
 
 describe("install Python packages action", () => {
   beforeEach(() => {
     installedPkgs = [];
+    savedPkgsCaches = [];
   });
 
   it("should successfully install packages", async () => {
@@ -20,6 +27,9 @@ describe("install Python packages action", () => {
     await expect(prom).resolves.toBeUndefined();
 
     expect(installedPkgs).toContain("black");
+    expect(savedPkgsCaches).toContain("black");
+
     expect(installedPkgs).toContain("ruff");
+    expect(savedPkgsCaches).toContain("ruff");
   });
 });


### PR DESCRIPTION
This pull request resolves #13 by updating the `pipxInstallAction` function to restore a package cache instead of performing an installation if the cache exists. If the cache is not found, it will install the package normally and then save the package cache.