### PR TITLE
Add `pipx.ensurePath` Function

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -81445,7 +81445,14 @@ var core = __nccwpck_require__(4278);
 var cache = __nccwpck_require__(294);
 // EXTERNAL MODULE: ./.yarn/cache/@actions-exec-npm-1.1.1-90973d2f96-4a09f6bdbe.zip/node_modules/@actions/exec/lib/exec.js
 var exec = __nccwpck_require__(8434);
+// EXTERNAL MODULE: external "os"
+var external_os_ = __nccwpck_require__(2037);
+// EXTERNAL MODULE: external "path"
+var external_path_ = __nccwpck_require__(1017);
 ;// CONCATENATED MODULE: ./src/pipx/environment.mjs
+
+
+
 
 async function getEnvironment(env) {
     try {
@@ -81456,9 +81463,14 @@ async function getEnvironment(env) {
         throw new Error(`Failed to get ${env}: ${err.message}`);
     }
 }
+function ensurePath() {
+    const homeDir = external_path_.join(external_os_.homedir(), ".local/pipx");
+    const binDir = external_path_.join(external_os_.homedir(), ".local/bin");
+    core.exportVariable("PIPX_HOME", homeDir);
+    core.exportVariable("PIPX_BIN_DIR", binDir);
+    core.addPath(binDir);
+}
 
-// EXTERNAL MODULE: external "path"
-var external_path_ = __nccwpck_require__(1017);
 ;// CONCATENATED MODULE: ./src/pipx/cache.mjs
 
 
@@ -81501,6 +81513,7 @@ async function installPackage(pkg) {
 
 
 /* harmony default export */ const pipx = ({
+    ensurePath: ensurePath,
     getEnvironment: getEnvironment,
     installPackage: installPackage,
     restorePackageCache: restorePackageCache,

--- a/src/pipx/environment.mts
+++ b/src/pipx/environment.mts
@@ -1,4 +1,7 @@
+import core from "@actions/core";
 import { getExecOutput } from "@actions/exec";
+import os from "os";
+import path from "path";
 
 export async function getEnvironment(env: string): Promise<string> {
   try {
@@ -7,4 +10,14 @@ export async function getEnvironment(env: string): Promise<string> {
   } catch (err) {
     throw new Error(`Failed to get ${env}: ${(err as Error).message}`);
   }
+}
+
+export function ensurePath() {
+  const homeDir = path.join(os.homedir(), ".local/pipx");
+  const binDir = path.join(os.homedir(), ".local/bin");
+
+  core.exportVariable("PIPX_HOME", homeDir);
+  core.exportVariable("PIPX_BIN_DIR", binDir);
+
+  core.addPath(binDir);
 }

--- a/src/pipx/environment.test.js
+++ b/src/pipx/environment.test.js
@@ -1,5 +1,19 @@
 import { jest } from "@jest/globals";
 
+let paths = [];
+let variables = {};
+
+jest.unstable_mockModule("@actions/core", () => ({
+  default: {
+    addPath: (inputPath) => {
+      paths.push(inputPath);
+    },
+    exportVariable: (name, val) => {
+      variables[name] = val;
+    },
+  },
+}));
+
 jest.unstable_mockModule("@actions/exec", () => ({
   getExecOutput: async (commandLine, args) => {
     expect(commandLine).toBe("pipx");
@@ -17,6 +31,12 @@ jest.unstable_mockModule("@actions/exec", () => ({
   },
 }));
 
+jest.unstable_mockModule("os", () => ({
+  default: {
+    homedir: () => "user-home",
+  },
+}));
+
 describe("get pipx environments", () => {
   it("should successfully get an environment", async () => {
     const { getEnvironment } = await import("./environment.mjs");
@@ -30,5 +50,26 @@ describe("get pipx environments", () => {
 
     const prom = getEnvironment("INVALID_ENV");
     await expect(prom).rejects.toThrow("Failed to get INVALID_ENV");
+  });
+});
+
+describe("ensure pipx path", () => {
+  beforeEach(() => {
+    paths = [];
+    variables = {
+      PIPX_HOME: "/path/to/home",
+      PIPX_BIN_DIR: "/path/to/bin",
+    };
+  });
+
+  it("should successfully ensure path", async () => {
+    const { ensurePath } = await import("./environment.mjs");
+
+    expect(() => ensurePath()).not.toThrow();
+
+    expect(variables["PIPX_HOME"]).toMatch(/^user-home/);
+    expect(variables["PIPX_BIN_DIR"]).toMatch(/^user-home/);
+
+    expect(paths).toContain(variables["PIPX_BIN_DIR"]);
   });
 });

--- a/src/pipx/index.mts
+++ b/src/pipx/index.mts
@@ -1,8 +1,9 @@
 import { restorePackageCache, savePackageCache } from "./cache.mjs";
-import { getEnvironment } from "./environment.mjs";
+import { ensurePath, getEnvironment } from "./environment.mjs";
 import { installPackage } from "./install.mjs";
 
 export default {
+  ensurePath,
   getEnvironment,
   installPackage,
   restorePackageCache,


### PR DESCRIPTION
This pull request resolves #43 by adding a `pipx.ensurePath` function alongside its testing.