### PR TITLE
Install Packages to Home Directory

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -81524,6 +81524,8 @@ async function installPackage(pkg) {
 
 
 async function pipxInstallAction(...pkgs) {
+    core.info("Ensuring pipx path...");
+    pipx.ensurePath();
     for (const pkg of pkgs) {
         const cacheFound = await core.group(`Restoring \u001b[34m${pkg}\u001b[39m cache...`, async () => {
             return pipx.restorePackageCache(pkg);

--- a/src/action.mts
+++ b/src/action.mts
@@ -2,6 +2,9 @@ import core from "@actions/core";
 import pipx from "./pipx/index.mjs";
 
 export async function pipxInstallAction(...pkgs: string[]): Promise<void> {
+  core.info("Ensuring pipx path...");
+  pipx.ensurePath();
+
   for (const pkg of pkgs) {
     const cacheFound = await core.group(
       `Restoring \u001b[34m${pkg}\u001b[39m cache...`,

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -5,6 +5,7 @@ let savedPkgsCaches = [];
 
 jest.unstable_mockModule("./pipx/index.mjs", () => ({
   default: {
+    ensurePath: () => {},
     installPackage: async (pkg) => {
       switch (pkg) {
         case "black":


### PR DESCRIPTION
This pull request resolves #41 by calling the `pipx.ensurePath` function in the `pipxInstallAction` function. This function will ensure that pipx packages are installed in the home directory and that the binary location of pipx packages is available in the paths.