### PR TITLE
Hide Command When Getting Pipx Environment

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -81456,7 +81456,9 @@ var external_path_ = __nccwpck_require__(1017);
 
 async function getEnvironment(env) {
     try {
-        const res = await (0,exec.getExecOutput)("pipx", ["environment", "--value", env]);
+        const res = await (0,exec.getExecOutput)("pipx", ["environment", "--value", env], {
+            silent: true,
+        });
         return res.stdout;
     }
     catch (err) {

--- a/src/pipx/environment.mts
+++ b/src/pipx/environment.mts
@@ -5,7 +5,9 @@ import path from "path";
 
 export async function getEnvironment(env: string): Promise<string> {
   try {
-    const res = await getExecOutput("pipx", ["environment", "--value", env]);
+    const res = await getExecOutput("pipx", ["environment", "--value", env], {
+      silent: true,
+    });
     return res.stdout;
   } catch (err) {
     throw new Error(`Failed to get ${env}: ${(err as Error).message}`);

--- a/src/pipx/environment.test.js
+++ b/src/pipx/environment.test.js
@@ -15,11 +15,13 @@ jest.unstable_mockModule("@actions/core", () => ({
 }));
 
 jest.unstable_mockModule("@actions/exec", () => ({
-  getExecOutput: async (commandLine, args) => {
+  getExecOutput: async (commandLine, args, options) => {
     expect(commandLine).toBe("pipx");
     expect(args.length).toBe(3);
     expect(args[0]).toBe("environment");
     expect(args[1]).toBe("--value");
+    expect(options).toBeDefined();
+    expect(options.silent).toBe(true);
 
     switch (args[2]) {
       case "PIPX_LOCAL_VENVS":


### PR DESCRIPTION
This pull request resolves #39 by running a command silently in the `getEnvironment` function to prevent it from outputting the executed command and the output log.