### PR TITLE
Use Prettier with Cache Enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "build": "tsc && ncc build src/main.mjs",
-    "format": "prettier --write . !dist",
+    "format": "prettier --write --cache . !dist",
     "lint": "eslint --ignore-path .gitignore .",
     "prepack": "tsc",
     "test": "tsc && jest"


### PR DESCRIPTION
This pull request resolves #54 by modifying the `format` script to call the `prettier` command with the `--cache` option enabled.