### PR TITLE
Configure Jest to Run Tests Verbosely

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -7,5 +7,6 @@
       "lines": 100,
       "statements": 100
     }
-  }
+  },
+  "verbose": true
 }


### PR DESCRIPTION
This pull request resolves #67 by configuring `verbose` option to `true` in the `jest.config.json` file.