### PR TITLE
Write Tests in TypeScript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,12 +17,6 @@
       "rules": {
         "tsdoc/syntax": "error"
       }
-    },
-    {
-      "files": ["**/*.test.*"],
-      "env": {
-        "jest": true
-      }
     }
   ]
 }

--- a/jest.config.json
+++ b/jest.config.json
@@ -8,5 +8,12 @@
       "statements": 100
     }
   },
+  "moduleNameMapper": {
+    "^(\\.{1,2}/.*)\\.mjs$": "$1.mts"
+  },
+  "preset": "ts-jest/presets/default-esm",
+  "transform": {
+    "^.+\\.m?ts$": ["ts-jest", { "useESM": true }]
+  },
   "verbose": true
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "format": "prettier --write --cache . !dist",
     "lint": "eslint --ignore-path .gitignore .",
     "prepack": "tsc",
-    "test": "tsc && jest"
+    "test": "jest"
   },
   "dependencies": {
     "@actions/cache": "^3.2.4",
@@ -38,6 +38,8 @@
     "@actions/exec": "^1.1.1"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@types/jest": "^29.5.12",
     "@types/node": "^20.11.20",
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "@typescript-eslint/parser": "^7.0.2",
@@ -46,6 +48,7 @@
     "eslint-plugin-tsdoc": "^0.2.17",
     "jest": "^29.7.0",
     "prettier": "^3.2.5",
+    "ts-jest": "^29.1.2",
     "typescript": "^5.3.3"
   },
   "packageManager": "yarn@4.0.2"

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -1,12 +1,12 @@
 import { jest } from "@jest/globals";
 
-let installedPkgs = [];
-let savedPkgsCaches = [];
+let installedPkgs: string[] = [];
+let savedPkgsCaches: string[] = [];
 
 jest.unstable_mockModule("./pipx/index.mjs", () => ({
   default: {
     ensurePath: () => {},
-    installPackage: async (pkg) => {
+    installPackage: async (pkg: string) => {
       switch (pkg) {
         case "black":
         case "ruff":
@@ -17,14 +17,14 @@ jest.unstable_mockModule("./pipx/index.mjs", () => ({
           throw new Error("unknown package");
       }
     },
-    restorePackageCache: async (pkg) => {
+    restorePackageCache: async (pkg: string) => {
       if (savedPkgsCaches.includes(pkg)) {
         installedPkgs.push(pkg);
         return true;
       }
       return false;
     },
-    savePackageCache: async (pkg) => {
+    savePackageCache: async (pkg: string) => {
       savedPkgsCaches.push(pkg);
     },
   },

--- a/src/pipx/cache.test.ts
+++ b/src/pipx/cache.test.ts
@@ -1,10 +1,10 @@
 import { jest } from "@jest/globals";
 
-let files = [];
-let cache = {};
+let files: string[] = [];
+let cache: { [key: string]: string[] } = {};
 
 jest.unstable_mockModule("./environment.mjs", () => ({
-  getEnvironment: async (env) => {
+  getEnvironment: async (env: string) => {
     switch (env) {
       case "PIPX_BIN_DIR":
         return "/path/to/bin";
@@ -15,7 +15,7 @@ jest.unstable_mockModule("./environment.mjs", () => ({
 }));
 
 jest.unstable_mockModule("@actions/cache", () => ({
-  restoreCache: async (paths, key) => {
+  restoreCache: async (paths: string[], key: string) => {
     if (key in cache) {
       for (const path of paths) {
         if (cache[key].includes(path)) {
@@ -28,7 +28,7 @@ jest.unstable_mockModule("@actions/cache", () => ({
     }
     return undefined;
   },
-  saveCache: async (paths, key) => {
+  saveCache: async (paths: string[], key: string) => {
     cache[key] = [];
     for (const path of paths) {
       if (files.includes(path)) {

--- a/src/pipx/environment.test.ts
+++ b/src/pipx/environment.test.ts
@@ -1,21 +1,25 @@
 import { jest } from "@jest/globals";
 
-let paths = [];
-let variables = {};
+let paths: string[] = [];
+let variables: { [key: string]: string } = {};
 
 jest.unstable_mockModule("@actions/core", () => ({
   default: {
-    addPath: (inputPath) => {
+    addPath: (inputPath: string) => {
       paths.push(inputPath);
     },
-    exportVariable: (name, val) => {
+    exportVariable: (name: string, val: string) => {
       variables[name] = val;
     },
   },
 }));
 
 jest.unstable_mockModule("@actions/exec", () => ({
-  getExecOutput: async (commandLine, args, options) => {
+  getExecOutput: async (
+    commandLine: string,
+    args: string[],
+    options: { silent: boolean },
+  ) => {
     expect(commandLine).toBe("pipx");
     expect(args.length).toBe(3);
     expect(args[0]).toBe("environment");

--- a/src/pipx/install.test.ts
+++ b/src/pipx/install.test.ts
@@ -1,9 +1,9 @@
 import { jest } from "@jest/globals";
 
-let installedPkgs = [];
+let installedPkgs: string[] = [];
 
 jest.unstable_mockModule("@actions/exec", () => ({
-  exec: async (commandLine, args) => {
+  exec: async (commandLine: string, args: string[]) => {
     expect(commandLine).toBe("pipx");
     expect(args.length).toBe(2);
     expect(args[0]).toBe("install");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,14 @@
 {
+  "include": ["src"],
+  "exclude": ["**/*.test.*"],
   "compilerOptions": {
     "exactOptionalPropertyTypes": true,
     "strict": true,
     "module": "node16",
+    "moduleResolution": "node16",
     "declaration": true,
+    "esModuleInterop": true,
     "target": "es2022",
     "skipLibCheck": true
-  },
-  "include": ["src"]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,6 +1192,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jest@npm:^29.5.12":
+  version: 29.5.12
+  resolution: "@types/jest@npm:29.5.12"
+  dependencies:
+    expect: "npm:^29.0.0"
+    pretty-format: "npm:^29.0.0"
+  checksum: 25fc8e4c611fa6c4421e631432e9f0a6865a8cb07c9815ec9ac90d630271cad773b2ee5fe08066f7b95bebd18bb967f8ce05d018ee9ab0430f9dfd1d84665b6f
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.12":
   version: 7.0.12
   resolution: "@types/json-schema@npm:7.0.12"
@@ -1715,6 +1725,15 @@ __metadata:
   bin:
     browserslist: cli.js
   checksum: e8c98496e5f2a5128d0e2f1f186dc0416bfc49c811e568b19c9e07a56cccc1f7f415fa4f532488e6a13dfacbe3332a9b55b152082ff125402696a11a158a0894
+  languageName: node
+  linkType: hard
+
+"bs-logger@npm:0.x":
+  version: 0.2.6
+  resolution: "bs-logger@npm:0.2.6"
+  dependencies:
+    fast-json-stable-stringify: "npm:2.x"
+  checksum: 80e89aaaed4b68e3374ce936f2eb097456a0dddbf11f75238dbd53140b1e39259f0d248a5089ed456f1158984f22191c3658d54a713982f676709fbe1a6fa5a0
   languageName: node
   linkType: hard
 
@@ -2328,7 +2347,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^29.7.0":
+"expect@npm:^29.0.0, expect@npm:^29.7.0":
   version: 29.7.0
   resolution: "expect@npm:29.7.0"
   dependencies:
@@ -2368,7 +2387,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
+"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: 7f081eb0b8a64e0057b3bb03f974b3ef00135fbf36c1c710895cd9300f13c94ba809bb3a81cf4e1b03f6e5285610a61abbd7602d0652de423144dfee5a389c9b
@@ -3362,7 +3381,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^29.7.0":
+"jest-util@npm:^29.0.0, jest-util@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-util@npm:29.7.0"
   dependencies:
@@ -3562,6 +3581,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.memoize@npm:4.x":
+  version: 4.1.2
+  resolution: "lodash.memoize@npm:4.1.2"
+  checksum: c8713e51eccc650422716a14cece1809cfe34bc5ab5e242b7f8b4e2241c2483697b971a604252807689b9dd69bfe3a98852e19a5b89d506b000b4187a1285df8
+  languageName: node
+  linkType: hard
+
 "lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
@@ -3607,6 +3633,13 @@ __metadata:
   dependencies:
     semver: "npm:^7.5.3"
   checksum: 69b98a6c0b8e5c4fe9acb61608a9fbcfca1756d910f51e5dbe7a9e5cfb74fca9b8a0c8a0ffdf1294a740826c1ab4871d5bf3f62f72a3049e5eac6541ddffed68
+  languageName: node
+  linkType: hard
+
+"make-error@npm:1.x":
+  version: 1.3.6
+  resolution: "make-error@npm:1.3.6"
+  checksum: 171e458d86854c6b3fc46610cfacf0b45149ba043782558c6875d9f42f222124384ad0b468c92e996d815a8a2003817a710c0a160e49c1c394626f76fa45396f
   languageName: node
   linkType: hard
 
@@ -4096,6 +4129,8 @@ __metadata:
     "@actions/cache": "npm:^3.2.4"
     "@actions/core": "npm:^1.10.1"
     "@actions/exec": "npm:^1.1.1"
+    "@jest/globals": "npm:^29.7.0"
+    "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.11.20"
     "@typescript-eslint/eslint-plugin": "npm:^7.0.2"
     "@typescript-eslint/parser": "npm:^7.0.2"
@@ -4104,6 +4139,7 @@ __metadata:
     eslint-plugin-tsdoc: "npm:^0.2.17"
     jest: "npm:^29.7.0"
     prettier: "npm:^3.2.5"
+    ts-jest: "npm:^29.1.2"
     typescript: "npm:^5.3.3"
   bin:
     pipx-install-action: src/main.mjs
@@ -4142,7 +4178,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^29.7.0":
+"pretty-format@npm:^29.0.0, pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
   dependencies:
@@ -4683,6 +4719,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-jest@npm:^29.1.2":
+  version: 29.1.2
+  resolution: "ts-jest@npm:29.1.2"
+  dependencies:
+    bs-logger: "npm:0.x"
+    fast-json-stable-stringify: "npm:2.x"
+    jest-util: "npm:^29.0.0"
+    json5: "npm:^2.2.3"
+    lodash.memoize: "npm:4.x"
+    make-error: "npm:1.x"
+    semver: "npm:^7.5.3"
+    yargs-parser: "npm:^21.0.1"
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/types": ^29.0.0
+    babel-jest: ^29.0.0
+    jest: ^29.0.0
+    typescript: ">=4.3 <6"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@jest/types":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: c2f51f0241f89d127d41392decbcb83b5dfd5e57ab9d50220aa7b7e2f9b3f3b07ccdbba33311284df1c41941879e4ddfad44b15a9d0da4b74bd1b98702b729df
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^1.10.0":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
@@ -4970,7 +5039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^21.1.1":
+"yargs-parser@npm:^21.0.1, yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: f84b5e48169479d2f402239c59f084cfd1c3acc197a05c59b98bab067452e6b3ea46d4dd8ba2985ba7b3d32a343d77df0debd6b343e5dae3da2aab2cdf5886b2


### PR DESCRIPTION
This pull request resolves #74 by introducing the following changes:

- Modifies test files to use TypeScript, effectively adding ts-jest to the dependency and configuring Jest and TypeScript accordingly.
- Removes configuration for Jest env in the `.eslintrc.json` file.