### PR TITLE
Utilize `.env.yarn` to Set `NODE_OPTIONS`

### DIFF
--- a/.env.yarn
+++ b/.env.yarn
@@ -1,0 +1,1 @@
+NODE_OPTIONS=--experimental-vm-modules

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,8 +49,6 @@ jobs:
 
       - name: Test Package
         run: yarn test
-        env:
-          NODE_OPTIONS: --experimental-vm-modules
 
   test-action:
     name: Test Action

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.env.yarn
 !.eslint*
 !.git*
 


### PR DESCRIPTION
This pull request resolves #88 by utilizing the `.env.yarn` file to set the `NODE_OPTIONS` environment variable.