### PR TITLE
Only Lint Source Files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "ncc build src/main.ts --out dist/action",
     "format": "prettier --write --cache . !dist",
-    "lint": "eslint --ignore-path .gitignore .",
+    "lint": "eslint src",
     "prepack": "tsc --declaration",
     "test": "jest"
   },


### PR DESCRIPTION
This pull request resolves #96 by modifying the `lint` command to only process source files in the `src` directory.