### PR TITLE
Utilize catched-error-message

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -81441,6 +81441,10 @@ var __webpack_exports__ = {};
 
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-core-npm-1.10.1-3cb1000b4d-10c0.zip/node_modules/@actions/core/lib/core.js
 var core = __nccwpck_require__(2340);
+;// CONCATENATED MODULE: ../../../.yarn/berry/cache/catched-error-message-npm-0.0.1-9126a73d25-10c0.zip/node_modules/catched-error-message/dist/index.esm.js
+function r(r){return function(r){if("object"==typeof(e=r)&&null!==e&&"message"in e&&"string"==typeof e.message)return r;var e;try{return new Error(JSON.stringify(r))}catch(e){return new Error(String(r))}}(r).message}
+//# sourceMappingURL=index.esm.js.map
+
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-cache-npm-3.2.4-c57b047f14-10c0.zip/node_modules/@actions/cache/lib/cache.js
 var cache = __nccwpck_require__(3193);
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-exec-npm-1.1.1-90973d2f96-10c0.zip/node_modules/@actions/exec/lib/exec.js
@@ -81454,6 +81458,7 @@ var external_path_ = __nccwpck_require__(1017);
 
 
 
+
 async function getEnvironment(env) {
     try {
         const res = await (0,exec.getExecOutput)("pipx", ["environment", "--value", env], {
@@ -81462,7 +81467,7 @@ async function getEnvironment(env) {
         return res.stdout;
     }
     catch (err) {
-        throw new Error(`Failed to get ${env}: ${err.message}`);
+        throw new Error(`Failed to get ${env}: ${r(err)}`);
     }
 }
 function ensurePath() {
@@ -81477,6 +81482,7 @@ function ensurePath() {
 
 
 
+
 async function savePackageCache(pkg) {
     try {
         const binDir = await getEnvironment("PIPX_BIN_DIR");
@@ -81484,7 +81490,7 @@ async function savePackageCache(pkg) {
         await (0,cache.saveCache)([external_path_.join(binDir, `${pkg}*`), external_path_.join(localVenvs, pkg)], `pipx-${process.platform}-${pkg}`);
     }
     catch (err) {
-        throw new Error(`Failed to save ${pkg} cache: ${err.message}`);
+        throw new Error(`Failed to save ${pkg} cache: ${r(err)}`);
     }
 }
 async function restorePackageCache(pkg) {
@@ -81495,18 +81501,19 @@ async function restorePackageCache(pkg) {
         return key !== undefined;
     }
     catch (err) {
-        throw new Error(`Failed to restore ${pkg} cache: ${err.message}`);
+        throw new Error(`Failed to restore ${pkg} cache: ${r(err)}`);
     }
 }
 
 ;// CONCATENATED MODULE: ./pipx-install-action/dist/pipx/install.js
+
 
 async function installPackage(pkg) {
     try {
         await (0,exec.exec)("pipx", ["install", pkg]);
     }
     catch (err) {
-        throw new Error(`Failed to install ${pkg}: ${err.message}`);
+        throw new Error(`Failed to install ${pkg}: ${r(err)}`);
     }
 }
 
@@ -81525,13 +81532,14 @@ async function installPackage(pkg) {
 ;// CONCATENATED MODULE: ./pipx-install-action/dist/action.js
 
 
+
 async function pipxInstallAction(...pkgs) {
     core.info("Ensuring pipx path...");
     try {
         pipx.ensurePath();
     }
     catch (err) {
-        core.setFailed(`Failed to ensure pipx path: ${err}`);
+        core.setFailed(`Failed to ensure pipx path: ${r(err)}`);
         return;
     }
     for (const pkg of pkgs) {
@@ -81542,7 +81550,7 @@ async function pipxInstallAction(...pkgs) {
         }
         catch (err) {
             core.endGroup();
-            core.setFailed(`Failed to restore ${pkg} cache: ${err}`);
+            core.setFailed(`Failed to restore ${pkg} cache: ${r(err)}`);
             return;
         }
         core.endGroup();
@@ -81553,7 +81561,7 @@ async function pipxInstallAction(...pkgs) {
             }
             catch (err) {
                 core.endGroup();
-                core.setFailed(`Failed to install ${pkg}: ${err}`);
+                core.setFailed(`Failed to install ${pkg}: ${r(err)}`);
                 return;
             }
             core.endGroup();
@@ -81563,7 +81571,7 @@ async function pipxInstallAction(...pkgs) {
             }
             catch (err) {
                 core.endGroup();
-                core.setFailed(`Failed to save ${pkg} cache: ${err}`);
+                core.setFailed(`Failed to save ${pkg} cache: ${r(err)}`);
                 return;
             }
             core.endGroup();

--- a/pipx-install-action/package.json
+++ b/pipx-install-action/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "@actions/cache": "^3.2.4",
     "@actions/core": "^1.10.1",
-    "@actions/exec": "^1.1.1"
+    "@actions/exec": "^1.1.1",
+    "catched-error-message": "^0.0.1"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/pipx-install-action/src/action.test.ts
+++ b/pipx-install-action/src/action.test.ts
@@ -88,7 +88,7 @@ describe("install Python packages action", () => {
     expect(failed).toBe(true);
     expect(logs.slice(-2)).toStrictEqual([
       "Ensuring pipx path...",
-      "Failed to ensure pipx path: Error: something happened",
+      "Failed to ensure pipx path: something happened",
     ]);
   });
 
@@ -106,7 +106,7 @@ describe("install Python packages action", () => {
     expect(logs.slice(-3)).toStrictEqual([
       "::group::Restoring \u001b[34many-pkg\u001b[39m cache...",
       "::endgroup::",
-      "Failed to restore any-pkg cache: Error: something happened",
+      "Failed to restore any-pkg cache: something happened",
     ]);
   });
 
@@ -124,7 +124,7 @@ describe("install Python packages action", () => {
     expect(logs.slice(-3)).toStrictEqual([
       "::group::Cache not found, installing \u001b[34many-pkg\u001b[39m...",
       "::endgroup::",
-      "Failed to install any-pkg: Error: something happened",
+      "Failed to install any-pkg: something happened",
     ]);
   });
 
@@ -142,7 +142,7 @@ describe("install Python packages action", () => {
     expect(logs.slice(-3)).toStrictEqual([
       "::group::Saving \u001b[34many-pkg\u001b[39m cache...",
       "::endgroup::",
-      "Failed to save any-pkg cache: Error: something happened",
+      "Failed to save any-pkg cache: something happened",
     ]);
   });
 });

--- a/pipx-install-action/src/action.ts
+++ b/pipx-install-action/src/action.ts
@@ -1,4 +1,5 @@
 import * as core from "@actions/core";
+import { getErrorMessage } from "catched-error-message";
 import pipx from "./pipx/index.js";
 
 export async function pipxInstallAction(...pkgs: string[]): Promise<void> {
@@ -6,7 +7,7 @@ export async function pipxInstallAction(...pkgs: string[]): Promise<void> {
   try {
     pipx.ensurePath();
   } catch (err) {
-    core.setFailed(`Failed to ensure pipx path: ${err}`);
+    core.setFailed(`Failed to ensure pipx path: ${getErrorMessage(err)}`);
     return;
   }
 
@@ -17,7 +18,7 @@ export async function pipxInstallAction(...pkgs: string[]): Promise<void> {
       cacheFound = await pipx.restorePackageCache(pkg);
     } catch (err) {
       core.endGroup();
-      core.setFailed(`Failed to restore ${pkg} cache: ${err}`);
+      core.setFailed(`Failed to restore ${pkg} cache: ${getErrorMessage(err)}`);
       return;
     }
     core.endGroup();
@@ -30,7 +31,7 @@ export async function pipxInstallAction(...pkgs: string[]): Promise<void> {
         await pipx.installPackage(pkg);
       } catch (err) {
         core.endGroup();
-        core.setFailed(`Failed to install ${pkg}: ${err}`);
+        core.setFailed(`Failed to install ${pkg}: ${getErrorMessage(err)}`);
         return;
       }
       core.endGroup();
@@ -40,7 +41,7 @@ export async function pipxInstallAction(...pkgs: string[]): Promise<void> {
         await pipx.savePackageCache(pkg);
       } catch (err) {
         core.endGroup();
-        core.setFailed(`Failed to save ${pkg} cache: ${err}`);
+        core.setFailed(`Failed to save ${pkg} cache: ${getErrorMessage(err)}`);
         return;
       }
       core.endGroup();

--- a/pipx-install-action/src/pipx/cache.ts
+++ b/pipx-install-action/src/pipx/cache.ts
@@ -1,4 +1,5 @@
 import { restoreCache, saveCache } from "@actions/cache";
+import { getErrorMessage } from "catched-error-message";
 import { getEnvironment } from "./environment.js";
 import path from "path";
 
@@ -12,7 +13,7 @@ export async function savePackageCache(pkg: string): Promise<void> {
       `pipx-${process.platform}-${pkg}`,
     );
   } catch (err) {
-    throw new Error(`Failed to save ${pkg} cache: ${(err as Error).message}`);
+    throw new Error(`Failed to save ${pkg} cache: ${getErrorMessage(err)}`);
   }
 }
 
@@ -28,8 +29,6 @@ export async function restorePackageCache(pkg: string): Promise<boolean> {
 
     return key !== undefined;
   } catch (err) {
-    throw new Error(
-      `Failed to restore ${pkg} cache: ${(err as Error).message}`,
-    );
+    throw new Error(`Failed to restore ${pkg} cache: ${getErrorMessage(err)}`);
   }
 }

--- a/pipx-install-action/src/pipx/environment.ts
+++ b/pipx-install-action/src/pipx/environment.ts
@@ -1,5 +1,6 @@
 import * as core from "@actions/core";
 import { getExecOutput } from "@actions/exec";
+import { getErrorMessage } from "catched-error-message";
 import os from "os";
 import path from "path";
 
@@ -10,7 +11,7 @@ export async function getEnvironment(env: string): Promise<string> {
     });
     return res.stdout;
   } catch (err) {
-    throw new Error(`Failed to get ${env}: ${(err as Error).message}`);
+    throw new Error(`Failed to get ${env}: ${getErrorMessage(err)}`);
   }
 }
 

--- a/pipx-install-action/src/pipx/install.ts
+++ b/pipx-install-action/src/pipx/install.ts
@@ -1,9 +1,10 @@
 import { exec } from "@actions/exec";
+import { getErrorMessage } from "catched-error-message";
 
 export async function installPackage(pkg: string): Promise<void> {
   try {
     await exec("pipx", ["install", pkg]);
   } catch (err) {
-    throw new Error(`Failed to install ${pkg}: ${(err as Error).message}`);
+    throw new Error(`Failed to install ${pkg}: ${getErrorMessage(err)}`);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1782,6 +1782,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"catched-error-message@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "catched-error-message@npm:0.0.1"
+  checksum: 10c0/1f10cd4323a73bec7a57b7495730e5dad9995120b04e85b5f654f7b40dc6a36320d95cc55e49cdf78753158e18790ef725e2ec7309ebced3acd6c9a557ac075b
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -4089,6 +4096,7 @@ __metadata:
     "@types/node": "npm:^20.11.24"
     "@typescript-eslint/eslint-plugin": "npm:^7.1.1"
     "@typescript-eslint/parser": "npm:^7.1.1"
+    catched-error-message: "npm:^0.0.1"
     eslint: "npm:^8.57.0"
     jest: "npm:^29.7.0"
     prettier: "npm:^3.2.5"


### PR DESCRIPTION
This pull request resolves #102 by utilizing the `getErrorMessage` function from the `catched-error-message` package to retrieve the error message from a caught error.