### PR TITLE
Add Readme and License to Library Workspace

### DIFF
--- a/pipx-install-action/LICENSE
+++ b/pipx-install-action/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Alfi Maulana
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pipx-install-action/README.md
+++ b/pipx-install-action/README.md
@@ -4,3 +4,8 @@ Install [Python](https://www.python.org/) packages using [pipx](https://pipx.pyp
 
 This JavaScript library provides a `pipxInstallAction` function similar to the [Pipx Install Action](https://github.com/threeal/pipx-install-action) for installing Python packages within GitHub Actions.
 Use this library to execute the Pipx Install Action in JavaScript, particularly when creating a [JavaScript action](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action) that requires steps for installing Python packages.
+
+## Key Features
+
+- Installs Python packages using pipx.
+- Caches Python package installations to be used in subsequent workflow runs.

--- a/pipx-install-action/README.md
+++ b/pipx-install-action/README.md
@@ -9,3 +9,13 @@ Use this library to execute the Pipx Install Action in JavaScript, particularly 
 
 - Installs Python packages using pipx.
 - Caches Python package installations to be used in subsequent workflow runs.
+
+## Examples
+
+This example demonstrates how to use the `pipxInstallAction` function to install the [Ruff](https://pypi.org/project/ruff/) package in a JavaScript action.
+
+```js
+import { pipxInstallAction } from "pipx-install-action";
+
+pipxInstallAction("ruff");
+```

--- a/pipx-install-action/README.md
+++ b/pipx-install-action/README.md
@@ -19,3 +19,9 @@ import { pipxInstallAction } from "pipx-install-action";
 
 pipxInstallAction("ruff");
 ```
+
+## License
+
+This project is licensed under the terms of the [MIT License](./LICENSE).
+
+Copyright © 2024 [Alfi Maulana](https://github.com/threeal/)

--- a/pipx-install-action/README.md
+++ b/pipx-install-action/README.md
@@ -1,0 +1,6 @@
+# pipx-install-action
+
+Install [Python](https://www.python.org/) packages using [pipx](https://pipx.pypa.io/stable/) on your [GitHub Actions](https://github.com/features/actions).
+
+This JavaScript library provides a `pipxInstallAction` function similar to the [Pipx Install Action](https://github.com/threeal/pipx-install-action) for installing Python packages within GitHub Actions.
+Use this library to execute the Pipx Install Action in JavaScript, particularly when creating a [JavaScript action](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action) that requires steps for installing Python packages.


### PR DESCRIPTION
This pull request resolves #110 by adding `README.md` and `LICENSE` files to the `pipx-install-action` workspace.