### PR TITLE
Set Root Workspace Name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "root",
   "type": "module",
   "workspaces": [
     "pipx-install-action"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4304,9 +4304,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"root-workspace-0b6124@workspace:.":
+"root@workspace:.":
   version: 0.0.0-use.local
-  resolution: "root-workspace-0b6124@workspace:."
+  resolution: "root@workspace:."
   dependencies:
     "@actions/core": "npm:^1.10.1"
     "@types/node": "npm:^20.11.27"


### PR DESCRIPTION
This pull request resolves #116 by simply setting the root workspace name to `root`.