### PR TITLE
Remove Badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # Pipx Install Action
 
-[![version](https://img.shields.io/github/v/release/threeal/pipx-install-action?style=flat-square)](https://github.com/threeal/pipx-install-action/releases)
-[![license](https://img.shields.io/github/license/threeal/pipx-install-action?style=flat-square)](./LICENSE)
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/pipx-install-action/build.yaml?branch=main&label=build&style=flat-square)](https://github.com/threeal/pipx-install-action/actions/workflows/build.yaml)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/pipx-install-action/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/pipx-install-action/actions/workflows/test.yaml)
-
 Install [Python](https://www.python.org/) packages using [pipx](https://pipx.pypa.io/stable/) with [cache support](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) on [GitHub Actions](https://github.com/features/actions).
 
 Use this action to install Python packages using pipx, especially for tools written in Python that should be installed in isolated environments.


### PR DESCRIPTION
This pull request resolves #119 by simply removing badges from the root `README.md` file.