### PR TITLE
Update Library `package.json` Before Release

### DIFF
--- a/lib/pipx-install-action/package.json
+++ b/lib/pipx-install-action/package.json
@@ -9,12 +9,16 @@
     "cache",
     "pipx"
   ],
-  "homepage": "https://github.com/threeal/pipx-install-action#readme",
+  "homepage": "https://github.com/threeal/pipx-install-action/tree/main/lib/pipx-install-action#readme",
   "bugs": {
     "url": "https://github.com/threeal/pipx-install-action/issues",
     "email": "alfi.maulana.f@gmail.com"
   },
-  "repository": "github:threeal/pipx-install-action",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/threeal/pipx-install-action.git",
+    "directory": "lib/pipx-install-action"
+  },
   "license": "MIT",
   "author": "Alfi Maulana <alfi.maulana.f@gmail.com>",
   "type": "module",

--- a/lib/pipx-install-action/package.json
+++ b/lib/pipx-install-action/package.json
@@ -24,7 +24,6 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "bin": "dist/main.js",
   "files": [
     "dist"
   ],

--- a/lib/pipx-install-action/package.json
+++ b/lib/pipx-install-action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipx-install-action",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Install Python packages using pipx with cache support on GitHub Actions",
   "keywords": [
     "action",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4102,8 +4102,6 @@ __metadata:
     prettier: "npm:^3.2.5"
     ts-jest: "npm:^29.1.2"
     typescript: "npm:^5.4.2"
-  bin:
-    pipx-install-action: dist/main.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This pull request resolves #121 by introducing the following changes to the `lib/pipx-install-action/package.json` file:
- Bumps the package version to `1.0.0`.
- Updates the homepage and repository URL.
- Removes `dist/main.js` from the binary entry point because it does not exist.