### PR TITLE
Mark Root Workspace as Private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "root",
+  "private": true,
   "type": "module",
   "workspaces": [
     "lib/*"


### PR DESCRIPTION
This pull request resolves #124 by setting the `private` option to `true` in the root workspace's `package.json` configuration file.