### PR TITLE
Set Pipx Variables Only During Pipx Command Execution

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -81459,6 +81459,8 @@ var external_path_ = __nccwpck_require__(1017);
 
 
 
+const homeDir = external_path_.join(external_os_.homedir(), ".local/pipx");
+const binDir = external_path_.join(external_os_.homedir(), ".local/bin");
 async function getEnvironment(env) {
     try {
         const res = await (0,exec.getExecOutput)("pipx", ["environment", "--value", env], {
@@ -81471,8 +81473,6 @@ async function getEnvironment(env) {
     }
 }
 function ensurePath() {
-    const homeDir = external_path_.join(external_os_.homedir(), ".local/pipx");
-    const binDir = external_path_.join(external_os_.homedir(), ".local/bin");
     core.exportVariable("PIPX_HOME", homeDir);
     core.exportVariable("PIPX_BIN_DIR", binDir);
     core.addPath(binDir);

--- a/dist/index.js
+++ b/dist/index.js
@@ -81465,6 +81465,10 @@ async function getEnvironment(env) {
     try {
         const res = await (0,exec.getExecOutput)("pipx", ["environment", "--value", env], {
             silent: true,
+            env: {
+                PIPX_HOME: homeDir,
+                PIPX_BIN_DIR: binDir,
+            },
         });
         return res.stdout;
     }
@@ -81473,8 +81477,6 @@ async function getEnvironment(env) {
     }
 }
 function ensurePath() {
-    core.exportVariable("PIPX_HOME", homeDir);
-    core.exportVariable("PIPX_BIN_DIR", binDir);
     core.addPath(binDir);
 }
 
@@ -81508,9 +81510,15 @@ async function restorePackageCache(pkg) {
 ;// CONCATENATED MODULE: ./lib/pipx-install-action/dist/pipx/install.js
 
 
+
 async function installPackage(pkg) {
     try {
-        await (0,exec.exec)("pipx", ["install", pkg]);
+        await (0,exec.exec)("pipx", ["install", pkg], {
+            env: {
+                PIPX_HOME: homeDir,
+                PIPX_BIN_DIR: binDir,
+            },
+        });
     }
     catch (err) {
         throw new Error(`Failed to install ${pkg}: ${r(err)}`);

--- a/lib/pipx-install-action/src/pipx/environment.test.ts
+++ b/lib/pipx-install-action/src/pipx/environment.test.ts
@@ -3,7 +3,6 @@ import "jest-extended";
 
 jest.unstable_mockModule("@actions/core", () => ({
   addPath: jest.fn(),
-  exportVariable: jest.fn(),
 }));
 
 jest.unstable_mockModule("@actions/exec", () => ({
@@ -13,7 +12,9 @@ jest.unstable_mockModule("@actions/exec", () => ({
 describe("get pipx environments", () => {
   it("should get an environment", async () => {
     const { getExecOutput } = await import("@actions/exec");
-    const { getEnvironment } = await import("./environment.js");
+    const { binDir, getEnvironment, homeDir } = await import(
+      "./environment.js"
+    );
 
     jest.mocked(getExecOutput).mockReset().mockResolvedValue({
       exitCode: 0,
@@ -29,6 +30,10 @@ describe("get pipx environments", () => {
       ["environment", "--value", "SOME_ENVIRONMENT"],
       {
         silent: true,
+        env: {
+          PIPX_HOME: homeDir,
+          PIPX_BIN_DIR: binDir,
+        },
       },
     );
   });
@@ -51,17 +56,12 @@ describe("get pipx environments", () => {
 
 describe("ensure pipx path", () => {
   it("should ensure path", async () => {
-    const { addPath, exportVariable } = await import("@actions/core");
-    const { binDir, ensurePath, homeDir } = await import("./environment.js");
+    const { addPath } = await import("@actions/core");
+    const { binDir, ensurePath } = await import("./environment.js");
 
     jest.mocked(addPath).mockReset();
-    jest.mocked(exportVariable).mockReset();
 
     expect(() => ensurePath()).not.toThrow();
-
-    expect(exportVariable).toHaveBeenCalledTimes(2);
-    expect(exportVariable).toHaveBeenNthCalledWith(1, "PIPX_HOME", homeDir);
-    expect(exportVariable).toHaveBeenNthCalledWith(2, "PIPX_BIN_DIR", binDir);
 
     expect(addPath).toHaveBeenCalledExactlyOnceWith(binDir);
   });

--- a/lib/pipx-install-action/src/pipx/environment.test.ts
+++ b/lib/pipx-install-action/src/pipx/environment.test.ts
@@ -1,6 +1,4 @@
 import { jest } from "@jest/globals";
-import path from "node:path";
-import os from "node:os";
 import "jest-extended";
 
 jest.unstable_mockModule("@actions/core", () => ({
@@ -54,7 +52,7 @@ describe("get pipx environments", () => {
 describe("ensure pipx path", () => {
   it("should ensure path", async () => {
     const { addPath, exportVariable } = await import("@actions/core");
-    const { ensurePath } = await import("./environment.js");
+    const { binDir, ensurePath, homeDir } = await import("./environment.js");
 
     jest.mocked(addPath).mockReset();
     jest.mocked(exportVariable).mockReset();
@@ -62,19 +60,9 @@ describe("ensure pipx path", () => {
     expect(() => ensurePath()).not.toThrow();
 
     expect(exportVariable).toHaveBeenCalledTimes(2);
-    expect(exportVariable).toHaveBeenNthCalledWith(
-      1,
-      "PIPX_HOME",
-      path.join(os.homedir(), ".local/pipx"),
-    );
-    expect(exportVariable).toHaveBeenNthCalledWith(
-      2,
-      "PIPX_BIN_DIR",
-      path.join(os.homedir(), ".local/bin"),
-    );
+    expect(exportVariable).toHaveBeenNthCalledWith(1, "PIPX_HOME", homeDir);
+    expect(exportVariable).toHaveBeenNthCalledWith(2, "PIPX_BIN_DIR", binDir);
 
-    expect(addPath).toHaveBeenCalledExactlyOnceWith(
-      path.join(os.homedir(), ".local/bin"),
-    );
+    expect(addPath).toHaveBeenCalledExactlyOnceWith(binDir);
   });
 });

--- a/lib/pipx-install-action/src/pipx/environment.ts
+++ b/lib/pipx-install-action/src/pipx/environment.ts
@@ -4,6 +4,9 @@ import { getErrorMessage } from "catched-error-message";
 import os from "os";
 import path from "path";
 
+export const homeDir = path.join(os.homedir(), ".local/pipx");
+export const binDir = path.join(os.homedir(), ".local/bin");
+
 export async function getEnvironment(env: string): Promise<string> {
   try {
     const res = await getExecOutput("pipx", ["environment", "--value", env], {
@@ -16,9 +19,6 @@ export async function getEnvironment(env: string): Promise<string> {
 }
 
 export function ensurePath() {
-  const homeDir = path.join(os.homedir(), ".local/pipx");
-  const binDir = path.join(os.homedir(), ".local/bin");
-
   core.exportVariable("PIPX_HOME", homeDir);
   core.exportVariable("PIPX_BIN_DIR", binDir);
 

--- a/lib/pipx-install-action/src/pipx/environment.ts
+++ b/lib/pipx-install-action/src/pipx/environment.ts
@@ -11,6 +11,10 @@ export async function getEnvironment(env: string): Promise<string> {
   try {
     const res = await getExecOutput("pipx", ["environment", "--value", env], {
       silent: true,
+      env: {
+        PIPX_HOME: homeDir,
+        PIPX_BIN_DIR: binDir,
+      },
     });
     return res.stdout;
   } catch (err) {
@@ -19,8 +23,5 @@ export async function getEnvironment(env: string): Promise<string> {
 }
 
 export function ensurePath() {
-  core.exportVariable("PIPX_HOME", homeDir);
-  core.exportVariable("PIPX_BIN_DIR", binDir);
-
   core.addPath(binDir);
 }

--- a/lib/pipx-install-action/src/pipx/install.test.ts
+++ b/lib/pipx-install-action/src/pipx/install.test.ts
@@ -1,4 +1,5 @@
 import { jest } from "@jest/globals";
+import { binDir, homeDir } from "./environment.js";
 import "jest-extended";
 
 jest.unstable_mockModule("@actions/exec", () => ({
@@ -15,10 +16,16 @@ describe("install Python packages", () => {
     const prom = installPackage("some-package");
     await expect(prom).resolves.toBeUndefined();
 
-    expect(exec).toHaveBeenCalledExactlyOnceWith("pipx", [
-      "install",
-      "some-package",
-    ]);
+    expect(exec).toHaveBeenCalledExactlyOnceWith(
+      "pipx",
+      ["install", "some-package"],
+      {
+        env: {
+          PIPX_HOME: homeDir,
+          PIPX_BIN_DIR: binDir,
+        },
+      },
+    );
   });
 
   it("should fail to install an package", async () => {

--- a/lib/pipx-install-action/src/pipx/install.ts
+++ b/lib/pipx-install-action/src/pipx/install.ts
@@ -1,9 +1,15 @@
 import { exec } from "@actions/exec";
 import { getErrorMessage } from "catched-error-message";
+import { binDir, homeDir } from "./environment.js";
 
 export async function installPackage(pkg: string): Promise<void> {
   try {
-    await exec("pipx", ["install", pkg]);
+    await exec("pipx", ["install", pkg], {
+      env: {
+        PIPX_HOME: homeDir,
+        PIPX_BIN_DIR: binDir,
+      },
+    });
   } catch (err) {
     throw new Error(`Failed to install ${pkg}: ${getErrorMessage(err)}`);
   }


### PR DESCRIPTION
This pull request resolves #127 by introducing the following changes:
- Exports the `pipx.homeDir` and `pipx.binDir` variables.
- Removes the `pipx.ensurePath` function from exporting pipx variables.
- Sets pipx variables during pipx command execution.