### PR TITLE
Mock Function for Testing

### DIFF
--- a/lib/pipx-install-action/jest.config.json
+++ b/lib/pipx-install-action/jest.config.json
@@ -12,6 +12,7 @@
     "^(\\.{1,2}/.*)\\.js$": "$1"
   },
   "preset": "ts-jest/presets/default-esm",
+  "setupFilesAfterEnv": ["jest-extended/all"],
   "transform": {
     "^.+\\.ts$": ["ts-jest", { "useESM": true }]
   },

--- a/lib/pipx-install-action/package.json
+++ b/lib/pipx-install-action/package.json
@@ -48,6 +48,7 @@
     "@typescript-eslint/parser": "^7.2.0",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
+    "jest-extended": "^4.0.2",
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",
     "typescript": "^5.4.2"

--- a/lib/pipx-install-action/src/pipx/cache.test.ts
+++ b/lib/pipx-install-action/src/pipx/cache.test.ts
@@ -1,4 +1,5 @@
 import { jest } from "@jest/globals";
+import "jest-extended";
 
 jest.unstable_mockModule("./environment.js", () => ({
   getEnvironment: jest.fn(),
@@ -33,8 +34,7 @@ describe("save Python package caches", () => {
     const prom = savePackageCache("some-package");
     await expect(prom).resolves.toBeUndefined();
 
-    expect(saveCache).toHaveBeenCalledTimes(1);
-    expect(saveCache).toHaveBeenLastCalledWith(
+    expect(saveCache).toHaveBeenCalledExactlyOnceWith(
       ["/path/to/bin/some-package*", "/path/to/venvs/some-package"],
       `pipx-${process.platform}-some-package`,
     );
@@ -71,8 +71,7 @@ describe("restore Python package caches", () => {
     const prom = restorePackageCache("some-package");
     await expect(prom).resolves.toBe(true);
 
-    expect(restoreCache).toHaveBeenCalledTimes(1);
-    expect(restoreCache).toHaveBeenLastCalledWith(
+    expect(restoreCache).toHaveBeenCalledExactlyOnceWith(
       ["/path/to/bin/some-package*", "/path/to/venvs/some-package"],
       `pipx-${process.platform}-some-package`,
     );
@@ -87,8 +86,7 @@ describe("restore Python package caches", () => {
     const prom = restorePackageCache("some-package");
     await expect(prom).resolves.toBe(false);
 
-    expect(restoreCache).toHaveBeenCalledTimes(1);
-    expect(restoreCache).toHaveBeenLastCalledWith(
+    expect(restoreCache).toHaveBeenCalledExactlyOnceWith(
       ["/path/to/bin/some-package*", "/path/to/venvs/some-package"],
       `pipx-${process.platform}-some-package`,
     );

--- a/lib/pipx-install-action/src/pipx/cache.test.ts
+++ b/lib/pipx-install-action/src/pipx/cache.test.ts
@@ -1,105 +1,113 @@
 import { jest } from "@jest/globals";
 
-let files: string[] = [];
-let cache: { [key: string]: string[] } = {};
-
 jest.unstable_mockModule("./environment.js", () => ({
-  getEnvironment: async (env: string) => {
+  getEnvironment: jest.fn(),
+}));
+
+jest.unstable_mockModule("@actions/cache", () => ({
+  restoreCache: jest.fn(),
+  saveCache: jest.fn(),
+}));
+
+beforeEach(async () => {
+  const { getEnvironment } = await import("./environment.js");
+
+  jest.mocked(getEnvironment).mockImplementation(async (env) => {
     switch (env) {
       case "PIPX_BIN_DIR":
         return "/path/to/bin";
       case "PIPX_LOCAL_VENVS":
         return "/path/to/venvs";
     }
-  },
-}));
-
-jest.unstable_mockModule("@actions/cache", () => ({
-  restoreCache: async (paths: string[], key: string) => {
-    if (key in cache) {
-      for (const path of paths) {
-        if (cache[key].includes(path)) {
-          if (!files.includes(path)) files.push(path);
-        } else {
-          throw new Error(`${path} not found`);
-        }
-      }
-      return key;
-    }
-    return undefined;
-  },
-  saveCache: async (paths: string[], key: string) => {
-    cache[key] = [];
-    for (const path of paths) {
-      if (files.includes(path)) {
-        cache[key].push(path);
-      } else {
-        throw new Error(`${path} not found`);
-      }
-    }
-  },
-}));
+    return "";
+  });
+});
 
 describe("save Python package caches", () => {
-  beforeEach(() => {
-    files = ["/path/to/bin/ruff*", "/path/to/venvs/ruff"];
-    cache = {};
-  });
-
-  it("should successfully save a package cache", async () => {
+  it("should save a package cache", async () => {
+    const { saveCache } = await import("@actions/cache");
     const { savePackageCache } = await import("./cache.js");
 
-    const prom = savePackageCache("ruff");
+    jest.mocked(saveCache).mockReset();
+
+    const prom = savePackageCache("some-package");
     await expect(prom).resolves.toBeUndefined();
 
-    expect(cache[`pipx-${process.platform}-ruff`]).toStrictEqual([
-      "/path/to/bin/ruff*",
-      "/path/to/venvs/ruff",
-    ]);
+    expect(saveCache).toHaveBeenCalledTimes(1);
+    expect(saveCache).toHaveBeenLastCalledWith(
+      ["/path/to/bin/some-package*", "/path/to/venvs/some-package"],
+      `pipx-${process.platform}-some-package`,
+    );
   });
 
   it("should fail to save a package cache", async () => {
+    const { saveCache } = await import("@actions/cache");
     const { savePackageCache } = await import("./cache.js");
 
-    const prom = savePackageCache("invalid-pkg");
-    await expect(prom).rejects.toThrow("Failed to save invalid-pkg cache");
+    jest
+      .mocked(saveCache)
+      .mockReset()
+      .mockImplementation(() => {
+        throw new Error("something went wrong");
+      });
+
+    const prom = savePackageCache("some-package");
+    await expect(prom).rejects.toThrow(
+      "Failed to save some-package cache: something went wrong",
+    );
   });
 });
 
 describe("restore Python package caches", () => {
-  beforeEach(() => {
-    files = [];
-    cache = {
-      [`pipx-${process.platform}-ruff`]: [
-        "/path/to/bin/ruff*",
-        "/path/to/venvs/ruff",
-      ],
-      [`pipx-${process.platform}-invalid-pkg`]: [],
-    };
-  });
-
-  it("should successfully restore a saved package cache", async () => {
+  it("should restore a saved package cache", async () => {
+    const { restoreCache } = await import("@actions/cache");
     const { restorePackageCache } = await import("./cache.js");
 
-    const prom = restorePackageCache("ruff");
+    jest
+      .mocked(restoreCache)
+      .mockReset()
+      .mockResolvedValue(`pipx-${process.platform}-some-package`);
+
+    const prom = restorePackageCache("some-package");
     await expect(prom).resolves.toBe(true);
 
-    expect(files).toStrictEqual(["/path/to/bin/ruff*", "/path/to/venvs/ruff"]);
+    expect(restoreCache).toHaveBeenCalledTimes(1);
+    expect(restoreCache).toHaveBeenLastCalledWith(
+      ["/path/to/bin/some-package*", "/path/to/venvs/some-package"],
+      `pipx-${process.platform}-some-package`,
+    );
   });
 
-  it("should successfully restore an unsaved package cache", async () => {
+  it("should restore an unsaved package cache", async () => {
+    const { restoreCache } = await import("@actions/cache");
     const { restorePackageCache } = await import("./cache.js");
 
-    const prom = restorePackageCache("black");
+    jest.mocked(restoreCache).mockReset().mockResolvedValue(undefined);
+
+    const prom = restorePackageCache("some-package");
     await expect(prom).resolves.toBe(false);
 
-    expect(files).toStrictEqual([]);
+    expect(restoreCache).toHaveBeenCalledTimes(1);
+    expect(restoreCache).toHaveBeenLastCalledWith(
+      ["/path/to/bin/some-package*", "/path/to/venvs/some-package"],
+      `pipx-${process.platform}-some-package`,
+    );
   });
 
   it("should fail to restore a package cache", async () => {
+    const { restoreCache } = await import("@actions/cache");
     const { restorePackageCache } = await import("./cache.js");
 
-    const prom = restorePackageCache("invalid-pkg");
-    await expect(prom).rejects.toThrow("Failed to restore invalid-pkg cache");
+    jest
+      .mocked(restoreCache)
+      .mockReset()
+      .mockImplementation(() => {
+        throw new Error("something went wrong");
+      });
+
+    const prom = restorePackageCache("some-package");
+    await expect(prom).rejects.toThrow(
+      "Failed to restore some-package cache: something went wrong",
+    );
   });
 });

--- a/lib/pipx-install-action/src/pipx/environment.test.ts
+++ b/lib/pipx-install-action/src/pipx/environment.test.ts
@@ -1,6 +1,7 @@
 import { jest } from "@jest/globals";
 import path from "node:path";
 import os from "node:os";
+import "jest-extended";
 
 jest.unstable_mockModule("@actions/core", () => ({
   addPath: jest.fn(),
@@ -25,8 +26,7 @@ describe("get pipx environments", () => {
     const prom = getEnvironment("SOME_ENVIRONMENT");
     await expect(prom).resolves.toBe("some value");
 
-    expect(getExecOutput).toHaveBeenCalledTimes(1);
-    expect(getExecOutput).toHaveBeenLastCalledWith(
+    expect(getExecOutput).toHaveBeenCalledExactlyOnceWith(
       "pipx",
       ["environment", "--value", "SOME_ENVIRONMENT"],
       {
@@ -73,8 +73,7 @@ describe("ensure pipx path", () => {
       path.join(os.homedir(), ".local/bin"),
     );
 
-    expect(addPath).toHaveBeenCalledTimes(1);
-    expect(addPath).toHaveBeenLastCalledWith(
+    expect(addPath).toHaveBeenCalledExactlyOnceWith(
       path.join(os.homedir(), ".local/bin"),
     );
   });

--- a/lib/pipx-install-action/src/pipx/environment.test.ts
+++ b/lib/pipx-install-action/src/pipx/environment.test.ts
@@ -1,79 +1,81 @@
 import { jest } from "@jest/globals";
-
-let paths: string[] = [];
-let variables: { [key: string]: string } = {};
+import path from "node:path";
+import os from "node:os";
 
 jest.unstable_mockModule("@actions/core", () => ({
-  addPath: (inputPath: string) => {
-    paths.push(inputPath);
-  },
-  exportVariable: (name: string, val: string) => {
-    variables[name] = val;
-  },
+  addPath: jest.fn(),
+  exportVariable: jest.fn(),
 }));
 
 jest.unstable_mockModule("@actions/exec", () => ({
-  getExecOutput: async (
-    commandLine: string,
-    args: string[],
-    options: { silent: boolean },
-  ) => {
-    expect(commandLine).toBe("pipx");
-    expect(args.length).toBe(3);
-    expect(args[0]).toBe("environment");
-    expect(args[1]).toBe("--value");
-    expect(options).toBeDefined();
-    expect(options.silent).toBe(true);
-
-    switch (args[2]) {
-      case "PIPX_LOCAL_VENVS":
-        return { stdout: "/path/to/venvs" };
-
-      default:
-        throw new Error("unknown environment");
-    }
-  },
-}));
-
-jest.unstable_mockModule("os", () => ({
-  default: {
-    homedir: () => "user-home",
-  },
+  getExecOutput: jest.fn(),
 }));
 
 describe("get pipx environments", () => {
-  it("should successfully get an environment", async () => {
+  it("should get an environment", async () => {
+    const { getExecOutput } = await import("@actions/exec");
     const { getEnvironment } = await import("./environment.js");
 
-    const prom = getEnvironment("PIPX_LOCAL_VENVS");
-    await expect(prom).resolves.toBe("/path/to/venvs");
+    jest.mocked(getExecOutput).mockReset().mockResolvedValue({
+      exitCode: 0,
+      stdout: "some value",
+      stderr: "",
+    });
+
+    const prom = getEnvironment("SOME_ENVIRONMENT");
+    await expect(prom).resolves.toBe("some value");
+
+    expect(getExecOutput).toHaveBeenCalledTimes(1);
+    expect(getExecOutput).toHaveBeenLastCalledWith(
+      "pipx",
+      ["environment", "--value", "SOME_ENVIRONMENT"],
+      {
+        silent: true,
+      },
+    );
   });
 
-  it("should fail to get an invalid environment", async () => {
+  it("should fail to get an environment", async () => {
+    const { getExecOutput } = await import("@actions/exec");
     const { getEnvironment } = await import("./environment.js");
 
-    const prom = getEnvironment("INVALID_ENV");
-    await expect(prom).rejects.toThrow("Failed to get INVALID_ENV");
+    jest
+      .mocked(getExecOutput)
+      .mockReset()
+      .mockRejectedValue(new Error("something went wrong"));
+
+    const prom = getEnvironment("SOME_ENVIRONMENT");
+    await expect(prom).rejects.toThrow(
+      "Failed to get SOME_ENVIRONMENT: something went wrong",
+    );
   });
 });
 
 describe("ensure pipx path", () => {
-  beforeEach(() => {
-    paths = [];
-    variables = {
-      PIPX_HOME: "/path/to/home",
-      PIPX_BIN_DIR: "/path/to/bin",
-    };
-  });
-
-  it("should successfully ensure path", async () => {
+  it("should ensure path", async () => {
+    const { addPath, exportVariable } = await import("@actions/core");
     const { ensurePath } = await import("./environment.js");
+
+    jest.mocked(addPath).mockReset();
+    jest.mocked(exportVariable).mockReset();
 
     expect(() => ensurePath()).not.toThrow();
 
-    expect(variables["PIPX_HOME"]).toMatch(/^user-home/);
-    expect(variables["PIPX_BIN_DIR"]).toMatch(/^user-home/);
+    expect(exportVariable).toHaveBeenCalledTimes(2);
+    expect(exportVariable).toHaveBeenNthCalledWith(
+      1,
+      "PIPX_HOME",
+      path.join(os.homedir(), ".local/pipx"),
+    );
+    expect(exportVariable).toHaveBeenNthCalledWith(
+      2,
+      "PIPX_BIN_DIR",
+      path.join(os.homedir(), ".local/bin"),
+    );
 
-    expect(paths).toContain(variables["PIPX_BIN_DIR"]);
+    expect(addPath).toHaveBeenCalledTimes(1);
+    expect(addPath).toHaveBeenLastCalledWith(
+      path.join(os.homedir(), ".local/bin"),
+    );
   });
 });

--- a/lib/pipx-install-action/src/pipx/install.test.ts
+++ b/lib/pipx-install-action/src/pipx/install.test.ts
@@ -1,4 +1,5 @@
 import { jest } from "@jest/globals";
+import "jest-extended";
 
 jest.unstable_mockModule("@actions/exec", () => ({
   exec: jest.fn(),
@@ -14,8 +15,10 @@ describe("install Python packages", () => {
     const prom = installPackage("some-package");
     await expect(prom).resolves.toBeUndefined();
 
-    expect(exec).toHaveBeenCalledTimes(1);
-    expect(exec).toHaveBeenLastCalledWith("pipx", ["install", "some-package"]);
+    expect(exec).toHaveBeenCalledExactlyOnceWith("pipx", [
+      "install",
+      "some-package",
+    ]);
   });
 
   it("should fail to install an package", async () => {

--- a/lib/pipx-install-action/src/pipx/install.test.ts
+++ b/lib/pipx-install-action/src/pipx/install.test.ts
@@ -1,42 +1,35 @@
 import { jest } from "@jest/globals";
 
-let installedPkgs: string[] = [];
-
 jest.unstable_mockModule("@actions/exec", () => ({
-  exec: async (commandLine: string, args: string[]) => {
-    expect(commandLine).toBe("pipx");
-    expect(args.length).toBe(2);
-    expect(args[0]).toBe("install");
-
-    switch (args[1]) {
-      case "ruff":
-        installedPkgs.push(args[1]);
-        break;
-
-      default:
-        throw new Error("unknown package");
-    }
-  },
+  exec: jest.fn(),
 }));
 
 describe("install Python packages", () => {
-  beforeEach(() => {
-    installedPkgs = [];
-  });
-
-  it("should successfully install a package", async () => {
+  it("should install a package", async () => {
+    const { exec } = await import("@actions/exec");
     const { installPackage } = await import("./install.js");
 
-    const prom = installPackage("ruff");
+    jest.mocked(exec).mockReset();
+
+    const prom = installPackage("some-package");
     await expect(prom).resolves.toBeUndefined();
 
-    expect(installedPkgs).toContain("ruff");
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenLastCalledWith("pipx", ["install", "some-package"]);
   });
 
-  it("should fail to install an invalid package", async () => {
+  it("should fail to install an package", async () => {
+    const { exec } = await import("@actions/exec");
     const { installPackage } = await import("./install.js");
 
-    const prom = installPackage("invalid-pkg");
-    await expect(prom).rejects.toThrow("Failed to install invalid-pkg");
+    jest
+      .mocked(exec)
+      .mockReset()
+      .mockRejectedValue(new Error("something went wrong"));
+
+    const prom = installPackage("some-package");
+    await expect(prom).rejects.toThrow(
+      "Failed to install some-package: something went wrong",
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3089,7 +3089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^29.7.0":
+"jest-diff@npm:^29.0.0, jest-diff@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-diff@npm:29.7.0"
   dependencies:
@@ -3137,7 +3137,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-get-type@npm:^29.6.3":
+"jest-extended@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "jest-extended@npm:4.0.2"
+  dependencies:
+    jest-diff: "npm:^29.0.0"
+    jest-get-type: "npm:^29.0.0"
+  peerDependencies:
+    jest: ">=27.2.5"
+  peerDependenciesMeta:
+    jest:
+      optional: true
+  checksum: 10c0/305fdb6885ab71755830b70690b8db6ea6fd9adca92360ea1a37c0d2fa6567a68b57178dd7707d112fc57b01ab75b66f28a1c550ed0e6b1b8628600a812c2277
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^29.0.0, jest-get-type@npm:^29.6.3":
   version: 29.6.3
   resolution: "jest-get-type@npm:29.6.3"
   checksum: 10c0/552e7a97a983d3c2d4e412a44eb7de0430ff773dd99f7500962c268d6dfbfa431d7d08f919c9d960530e5f7f78eb47f267ad9b318265e5092b3ff9ede0db7c2b
@@ -4099,6 +4114,7 @@ __metadata:
     catched-error-message: "npm:^0.0.1"
     eslint: "npm:^8.57.0"
     jest: "npm:^29.7.0"
+    jest-extended: "npm:^4.0.2"
     prettier: "npm:^3.2.5"
     ts-jest: "npm:^29.1.2"
     typescript: "npm:^5.4.2"


### PR DESCRIPTION
This pull request resolves #129 by modifying test files in the `pipx` directory of the `pipx-install-action` workspace. It modifies the test files to utilize `jest.fn()` to mock functions and modifies the testing accordingly. It also adds [jest-extended](https://www.npmjs.com/package/jest-extended) as a dependency to extend available assertions to be used in testing.