### PR TITLE
Install Specific Version of Package

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,7 +70,14 @@ jobs:
       - name: Install Packages
         uses: ./pipx-install-action
         with:
-          packages: black ruff
+          packages: black ruff==0.3.0
 
       - name: Check Packages
-        run: black --version && ruff --version
+        shell: bash
+        run: |
+          black --version
+          VERSION="$(ruff --version)"
+          if [ "$VERSION" != "ruff 0.3.0" ]; then
+            echo "Expected 'ruff 0.3.0' but instead got '$VERSION'"
+            exit 1
+          fi


### PR DESCRIPTION
This pull request resolve #137 by modifying the `test-action` job to install one of the packages on a specific version and asserts if it is installed with the specified version.