### PR TITLE
Disable Jest from Writing Report Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 !.git*
 !.prettierignore
 
-coverage/
 node_modules/
 
 package.tgz

--- a/lib/pipx-install-action/.gitignore
+++ b/lib/pipx-install-action/.gitignore
@@ -1,2 +1,1 @@
-coverage/
 dist/

--- a/lib/pipx-install-action/jest.config.json
+++ b/lib/pipx-install-action/jest.config.json
@@ -1,5 +1,6 @@
 {
   "collectCoverage": true,
+  "coverageReporters": ["text"],
   "coverageThreshold": {
     "global": {
       "branches": 100,


### PR DESCRIPTION
This pull request resolves #149 by disabling Jest from writing report files in the `coverage` directory, thereby cleaning up the workspace from unused generated files.