### PR TITLE
Run ESLint with No File Arguments

### DIFF
--- a/lib/pipx-install-action/package.json
+++ b/lib/pipx-install-action/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "tsc",
     "format": "prettier --write --cache .",
-    "lint": "eslint .",
+    "lint": "eslint",
     "prepack": "tsc",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "ncc build src/index.ts",
     "format": "prettier --write --cache .",
-    "lint": "eslint ."
+    "lint": "eslint"
   },
   "dependencies": {
     "@actions/core": "^1.10.1",


### PR DESCRIPTION
This pull request simply resolves #158 by modifying the `lint` script in the `package.json` file to run the `eslint` command with no file arguments.