### PR TITLE
Fix Build Diff Check in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,6 +49,7 @@ jobs:
           version: stable
 
       - name: Build Workspaces
-        run: |
-          yarn workspaces foreach --all --topological run build
-          git diff --exit-code HEAD
+        run: yarn workspaces foreach --all --topological run build
+
+      - name: Check Diff
+        run: git diff --exit-code HEAD

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,4 +52,4 @@ jobs:
         run: yarn workspaces foreach --all --topological run build
 
       - name: Check Diff
-        run: git diff --exit-code HEAD
+        run: git diff && git diff-index --quiet --exit-code HEAD

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,7 +26,7 @@ jobs:
         run: yarn workspaces foreach --all --topological run format
 
       - name: Check Diff
-        run: git diff --exit-code HEAD
+        run: git diff && git diff-index --quiet --exit-code HEAD
 
       - name: Check Lint
         run: yarn workspaces foreach --all --topological run lint

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,9 +23,10 @@ jobs:
           version: stable
 
       - name: Check Format
-        run: |
-          yarn workspaces foreach --all --topological run format
-          git diff --exit-code HEAD
+        run: yarn workspaces foreach --all --topological run format
+
+      - name: Check Diff
+        run: git diff --exit-code HEAD
 
       - name: Check Lint
         run: yarn workspaces foreach --all --topological run lint


### PR DESCRIPTION
This pull request resolves #248 by separating the Git diff check into separate steps and modifying them to utilize the `git diff-index` command for asserting whether there are changes in the diff.