### PR TITLE
Utilize GitHub Actions Utilities Package

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -80234,21 +80234,19 @@ exports.AbortError = AbortError;
 /***/ ((module, __unused_webpack___webpack_exports__, __nccwpck_require__) => {
 
 __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __webpack_async_result__) => { try {
-/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(2340);
-/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony import */ var catched_error_message__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(144);
-/* harmony import */ var pipx_install_action__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(3237);
-
+/* harmony import */ var gha_utils__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(3410);
+/* harmony import */ var pipx_install_action__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(3914);
 
 
 try {
-    const pkgs = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput("packages", { required: true })
+    const pkgs = (0,gha_utils__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .Np)("packages")
         .split(/(\s+)/)
         .filter((pkg) => pkg.trim().length > 0);
     await (0,pipx_install_action__WEBPACK_IMPORTED_MODULE_1__/* .pipxInstallAction */ .y)(...pkgs);
 }
 catch (err) {
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed((0,catched_error_message__WEBPACK_IMPORTED_MODULE_2__/* .getErrorMessage */ .e)(err));
+    (0,gha_utils__WEBPACK_IMPORTED_MODULE_0__/* .logError */ .H)(err);
+    process.exit(1);
 }
 
 __webpack_async_result__();
@@ -82080,29 +82078,22 @@ module.exports = parseParams
 
 /***/ }),
 
-/***/ 144:
-/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
-
-/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
-/* harmony export */   "e": () => (/* binding */ r)
-/* harmony export */ });
-function r(r){return function(r){if("object"==typeof(e=r)&&null!==e&&"message"in e&&"string"==typeof e.message)return r;var e;try{return new Error(JSON.stringify(r))}catch(e){return new Error(String(r))}}(r).message}
-//# sourceMappingURL=index.esm.js.map
-
-
-/***/ }),
-
-/***/ 3237:
+/***/ 3410:
 /***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
 
 
 // EXPORTS
 __nccwpck_require__.d(__webpack_exports__, {
-  "y": () => (/* reexport */ pipxInstallAction)
+  "QM": () => (/* binding */ addPath),
+  "zq": () => (/* binding */ beginLogGroup),
+  "sH": () => (/* binding */ endLogGroup),
+  "Np": () => (/* binding */ getInput),
+  "H": () => (/* binding */ logError),
+  "PN": () => (/* binding */ logInfo)
 });
 
-// EXTERNAL MODULE: ../../../.yarn/berry/cache/catched-error-message-npm-0.0.1-9126a73d25-10c0.zip/node_modules/catched-error-message/dist/index.esm.js
-var index_esm = __nccwpck_require__(144);
+// UNUSED EXPORTS: logCommand, logWarning, setEnv, setOutput
+
 ;// CONCATENATED MODULE: external "node:fs"
 const external_node_fs_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:fs");
 ;// CONCATENATED MODULE: external "node:os"
@@ -82201,6 +82192,24 @@ function endLogGroup() {
     process.stdout.write(`::endgroup::${external_node_os_namespaceObject.EOL}`);
 }
 
+
+/***/ }),
+
+/***/ 3914:
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
+
+
+// EXPORTS
+__nccwpck_require__.d(__webpack_exports__, {
+  "y": () => (/* reexport */ pipxInstallAction)
+});
+
+;// CONCATENATED MODULE: ../../../.yarn/berry/cache/catched-error-message-npm-0.0.1-9126a73d25-10c0.zip/node_modules/catched-error-message/dist/index.esm.js
+function r(r){return function(r){if("object"==typeof(e=r)&&null!==e&&"message"in e&&"string"==typeof e.message)return r;var e;try{return new Error(JSON.stringify(r))}catch(e){return new Error(String(r))}}(r).message}
+//# sourceMappingURL=index.esm.js.map
+
+// EXTERNAL MODULE: ../../../.yarn/berry/cache/gha-utils-npm-0.2.0-572860ffdf-10c0.zip/node_modules/gha-utils/dist/index.js + 3 modules
+var dist = __nccwpck_require__(3410);
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-cache-npm-3.2.4-c57b047f14-10c0.zip/node_modules/@actions/cache/lib/cache.js
 var cache = __nccwpck_require__(3193);
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-exec-npm-1.1.1-90973d2f96-10c0.zip/node_modules/@actions/exec/lib/exec.js
@@ -82229,11 +82238,11 @@ async function getEnvironment(env) {
         return res.stdout;
     }
     catch (err) {
-        throw new Error(`Failed to get ${env}: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+        throw new Error(`Failed to get ${env}: ${r(err)}`);
     }
 }
 function ensurePath() {
-    addPath(binDir);
+    (0,dist/* addPath */.QM)(binDir);
 }
 
 ;// CONCATENATED MODULE: ./lib/pipx-install-action/dist/pipx/cache.js
@@ -82248,7 +82257,7 @@ async function savePackageCache(pkg) {
         await (0,cache.saveCache)([external_path_.join(binDir, `${pkg}*`), external_path_.join(localVenvs, pkg)], `pipx-${process.platform}-${pkg}`);
     }
     catch (err) {
-        throw new Error(`Failed to save ${pkg} cache: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+        throw new Error(`Failed to save ${pkg} cache: ${r(err)}`);
     }
 }
 async function restorePackageCache(pkg) {
@@ -82259,7 +82268,7 @@ async function restorePackageCache(pkg) {
         return key !== undefined;
     }
     catch (err) {
-        throw new Error(`Failed to restore ${pkg} cache: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+        throw new Error(`Failed to restore ${pkg} cache: ${r(err)}`);
     }
 }
 
@@ -82277,7 +82286,7 @@ async function installPackage(pkg) {
         });
     }
     catch (err) {
-        throw new Error(`Failed to install ${pkg}: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+        throw new Error(`Failed to install ${pkg}: ${r(err)}`);
     }
 }
 
@@ -82298,51 +82307,51 @@ async function installPackage(pkg) {
 
 
 async function pipxInstallAction(...pkgs) {
-    logInfo("Ensuring pipx path...");
+    (0,dist/* logInfo */.PN)("Ensuring pipx path...");
     try {
         pipx.ensurePath();
     }
     catch (err) {
-        logError(`Failed to ensure pipx path: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+        (0,dist/* logError */.H)(`Failed to ensure pipx path: ${r(err)}`);
         process.exitCode = 1;
         return;
     }
     for (const pkg of pkgs) {
         let cacheFound;
-        beginLogGroup(`Restoring \u001b[34m${pkg}\u001b[39m cache...`);
+        (0,dist/* beginLogGroup */.zq)(`Restoring \u001b[34m${pkg}\u001b[39m cache...`);
         try {
             cacheFound = await pipx.restorePackageCache(pkg);
         }
         catch (err) {
-            endLogGroup();
-            logError(`Failed to restore ${pkg} cache: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+            (0,dist/* endLogGroup */.sH)();
+            (0,dist/* logError */.H)(`Failed to restore ${pkg} cache: ${r(err)}`);
             process.exitCode = 1;
             return;
         }
-        endLogGroup();
+        (0,dist/* endLogGroup */.sH)();
         if (!cacheFound) {
-            beginLogGroup(`Cache not found, installing \u001b[34m${pkg}\u001b[39m...`);
+            (0,dist/* beginLogGroup */.zq)(`Cache not found, installing \u001b[34m${pkg}\u001b[39m...`);
             try {
                 await pipx.installPackage(pkg);
             }
             catch (err) {
-                endLogGroup();
-                logError(`Failed to install ${pkg}: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+                (0,dist/* endLogGroup */.sH)();
+                (0,dist/* logError */.H)(`Failed to install ${pkg}: ${r(err)}`);
                 process.exitCode = 1;
                 return;
             }
-            endLogGroup();
-            beginLogGroup(`Saving \u001b[34m${pkg}\u001b[39m cache...`);
+            (0,dist/* endLogGroup */.sH)();
+            (0,dist/* beginLogGroup */.zq)(`Saving \u001b[34m${pkg}\u001b[39m cache...`);
             try {
                 await pipx.savePackageCache(pkg);
             }
             catch (err) {
-                endLogGroup();
-                logError(`Failed to save ${pkg} cache: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+                (0,dist/* endLogGroup */.sH)();
+                (0,dist/* logError */.H)(`Failed to save ${pkg} cache: ${r(err)}`);
                 process.exitCode = 1;
                 return;
             }
-            endLogGroup();
+            (0,dist/* endLogGroup */.sH)();
         }
     }
 }
@@ -82466,18 +82475,6 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /******/ 			return fn.r ? promise : getResult();
 /******/ 		}, (err) => ((err ? reject(promise[webpackError] = err) : outerResolve(exports)), resolveQueue(queue)));
 /******/ 		queue && (queue.d = 0);
-/******/ 	};
-/******/ })();
-/******/ 
-/******/ /* webpack/runtime/compat get default export */
-/******/ (() => {
-/******/ 	// getDefaultExport function for compatibility with non-harmony modules
-/******/ 	__nccwpck_require__.n = (module) => {
-/******/ 		var getter = module && module.__esModule ?
-/******/ 			() => (module['default']) :
-/******/ 			() => (module);
-/******/ 		__nccwpck_require__.d(getter, { a: getter });
-/******/ 		return getter;
 /******/ 	};
 /******/ })();
 /******/ 

--- a/dist/index.js
+++ b/dist/index.js
@@ -80237,7 +80237,7 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(2340);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var catched_error_message__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(144);
-/* harmony import */ var pipx_install_action__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(6234);
+/* harmony import */ var pipx_install_action__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(3237);
 
 
 
@@ -82092,7 +82092,7 @@ function r(r){return function(r){if("object"==typeof(e=r)&&null!==e&&"message"in
 
 /***/ }),
 
-/***/ 6234:
+/***/ 3237:
 /***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
 
 
@@ -82101,10 +82101,106 @@ __nccwpck_require__.d(__webpack_exports__, {
   "y": () => (/* reexport */ pipxInstallAction)
 });
 
-// EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-core-npm-1.10.1-3cb1000b4d-10c0.zip/node_modules/@actions/core/lib/core.js
-var core = __nccwpck_require__(2340);
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/catched-error-message-npm-0.0.1-9126a73d25-10c0.zip/node_modules/catched-error-message/dist/index.esm.js
 var index_esm = __nccwpck_require__(144);
+;// CONCATENATED MODULE: external "node:fs"
+const external_node_fs_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:fs");
+;// CONCATENATED MODULE: external "node:os"
+const external_node_os_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:os");
+;// CONCATENATED MODULE: external "node:path"
+const external_node_path_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:path");
+;// CONCATENATED MODULE: ../../../.yarn/berry/cache/gha-utils-npm-0.2.0-572860ffdf-10c0.zip/node_modules/gha-utils/dist/index.js
+
+
+
+/**
+ * Retrieves the value of a GitHub Actions input.
+ *
+ * @param name - The name of the GitHub Actions input.
+ * @returns The value of the GitHub Actions input, or an empty string if not found.
+ */
+function getInput(name) {
+    const value = process.env[`INPUT_${name.toUpperCase()}`] || "";
+    return value.trim();
+}
+/**
+ * Sets the value of a GitHub Actions output.
+ *
+ * @param name - The name of the GitHub Actions output.
+ * @param value - The value of the GitHub Actions output
+ */
+function setOutput(name, value) {
+    fs.appendFileSync(process.env["GITHUB_OUTPUT"], `${name}=${value}${os.EOL}`);
+}
+/**
+ * Sets the value of an environment variable in GitHub Actions.
+ *
+ * @param name - The name of the environment variable.
+ * @param value - The value of the environment variable.
+ */
+function setEnv(name, value) {
+    process.env[name] = value;
+    fs.appendFileSync(process.env["GITHUB_ENV"], `${name}=${value}${os.EOL}`);
+}
+/**
+ * Adds a system path to the environment in GitHub Actions.
+ *
+ * @param sysPath - The system path to add.
+ */
+function addPath(sysPath) {
+    process.env["PATH"] = `${sysPath}${external_node_path_namespaceObject.delimiter}${process.env["PATH"]}`;
+    external_node_fs_namespaceObject.appendFileSync(process.env["GITHUB_PATH"], `${sysPath}${external_node_os_namespaceObject.EOL}`);
+}
+/**
+ * Logs an information message in GitHub Actions.
+ *
+ * @param message - The information message to log.
+ */
+function logInfo(message) {
+    process.stdout.write(`${message}${external_node_os_namespaceObject.EOL}`);
+}
+/**
+ * Logs a warning message in GitHub Actions.
+ *
+ * @param message - The warning message to log.
+ */
+function logWarning(message) {
+    process.stdout.write(`::warning::${message}${os.EOL}`);
+}
+/**
+ * Logs an error message in GitHub Actions.
+ *
+ * @param err - The error, which can be of any type.
+ */
+function logError(err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stdout.write(`::error::${message}${external_node_os_namespaceObject.EOL}`);
+}
+/**
+ * Logs a command along with its arguments in GitHub Actions.
+ *
+ * @param command - The command to log.
+ * @param args - The arguments of the command.
+ */
+function logCommand(command, args) {
+    const message = [command, ...args].join(" ");
+    process.stdout.write(`[command]${message}${os.EOL}`);
+}
+/**
+ * Begins a log group in GitHub Actions.
+ *
+ * @param name - The name of the log group.
+ */
+function beginLogGroup(name) {
+    process.stdout.write(`::group::${name}${external_node_os_namespaceObject.EOL}`);
+}
+/**
+ * Ends the current log group in GitHub Actions.
+ */
+function endLogGroup() {
+    process.stdout.write(`::endgroup::${external_node_os_namespaceObject.EOL}`);
+}
+
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-cache-npm-3.2.4-c57b047f14-10c0.zip/node_modules/@actions/cache/lib/cache.js
 var cache = __nccwpck_require__(3193);
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-exec-npm-1.1.1-90973d2f96-10c0.zip/node_modules/@actions/exec/lib/exec.js
@@ -82137,7 +82233,7 @@ async function getEnvironment(env) {
     }
 }
 function ensurePath() {
-    core.addPath(binDir);
+    addPath(binDir);
 }
 
 ;// CONCATENATED MODULE: ./lib/pipx-install-action/dist/pipx/cache.js
@@ -82202,47 +82298,51 @@ async function installPackage(pkg) {
 
 
 async function pipxInstallAction(...pkgs) {
-    core.info("Ensuring pipx path...");
+    logInfo("Ensuring pipx path...");
     try {
         pipx.ensurePath();
     }
     catch (err) {
-        core.setFailed(`Failed to ensure pipx path: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+        logError(`Failed to ensure pipx path: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+        process.exitCode = 1;
         return;
     }
     for (const pkg of pkgs) {
         let cacheFound;
-        core.startGroup(`Restoring \u001b[34m${pkg}\u001b[39m cache...`);
+        beginLogGroup(`Restoring \u001b[34m${pkg}\u001b[39m cache...`);
         try {
             cacheFound = await pipx.restorePackageCache(pkg);
         }
         catch (err) {
-            core.endGroup();
-            core.setFailed(`Failed to restore ${pkg} cache: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+            endLogGroup();
+            logError(`Failed to restore ${pkg} cache: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+            process.exitCode = 1;
             return;
         }
-        core.endGroup();
+        endLogGroup();
         if (!cacheFound) {
-            core.startGroup(`Cache not found, installing \u001b[34m${pkg}\u001b[39m...`);
+            beginLogGroup(`Cache not found, installing \u001b[34m${pkg}\u001b[39m...`);
             try {
                 await pipx.installPackage(pkg);
             }
             catch (err) {
-                core.endGroup();
-                core.setFailed(`Failed to install ${pkg}: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+                endLogGroup();
+                logError(`Failed to install ${pkg}: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+                process.exitCode = 1;
                 return;
             }
-            core.endGroup();
-            core.startGroup(`Saving \u001b[34m${pkg}\u001b[39m cache...`);
+            endLogGroup();
+            beginLogGroup(`Saving \u001b[34m${pkg}\u001b[39m cache...`);
             try {
                 await pipx.savePackageCache(pkg);
             }
             catch (err) {
-                core.endGroup();
-                core.setFailed(`Failed to save ${pkg} cache: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+                endLogGroup();
+                logError(`Failed to save ${pkg} cache: ${(0,index_esm/* getErrorMessage */.e)(err)}`);
+                process.exitCode = 1;
                 return;
             }
-            core.endGroup();
+            endLogGroup();
         }
     }
 }

--- a/lib/pipx-install-action/package.json
+++ b/lib/pipx-install-action/package.json
@@ -36,9 +36,9 @@
   },
   "dependencies": {
     "@actions/cache": "^3.2.4",
-    "@actions/core": "^1.10.1",
     "@actions/exec": "^1.1.1",
-    "catched-error-message": "^0.0.1"
+    "catched-error-message": "^0.0.1",
+    "gha-utils": "^0.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/lib/pipx-install-action/src/action.test.ts
+++ b/lib/pipx-install-action/src/action.test.ts
@@ -1,22 +1,22 @@
-import type * as core from "@actions/core";
 import { jest } from "@jest/globals";
+import type { beginLogGroup, endLogGroup, logError, logInfo } from "gha-utils";
 
-let logs: (string | Error)[];
+let logs: unknown[];
 let failed: boolean;
 
-jest.unstable_mockModule("@actions/core", () => ({
-  endGroup: jest.fn<typeof core.endGroup>(() => {
+jest.unstable_mockModule("gha-utils", () => ({
+  beginLogGroup: jest.fn<typeof beginLogGroup>((name) => {
+    logs.push(`::group::${name}`);
+  }),
+  endLogGroup: jest.fn<typeof endLogGroup>(() => {
     logs.push("::endgroup::");
   }),
-  info: jest.fn<typeof core.info>((message) => {
-    logs.push(message);
-  }),
-  setFailed: jest.fn<typeof core.setFailed>((message) => {
+  logError: jest.fn<typeof logError>((message) => {
     failed = true;
     logs.push(message);
   }),
-  startGroup: jest.fn<typeof core.startGroup>((name) => {
-    logs.push(`::group::${name}`);
+  logInfo: jest.fn<typeof logInfo>((message) => {
+    logs.push(message);
   }),
 }));
 

--- a/lib/pipx-install-action/src/pipx/environment.test.ts
+++ b/lib/pipx-install-action/src/pipx/environment.test.ts
@@ -1,12 +1,12 @@
 import { jest } from "@jest/globals";
 import "jest-extended";
 
-jest.unstable_mockModule("@actions/core", () => ({
-  addPath: jest.fn(),
-}));
-
 jest.unstable_mockModule("@actions/exec", () => ({
   getExecOutput: jest.fn(),
+}));
+
+jest.unstable_mockModule("gha-utils", () => ({
+  addPath: jest.fn(),
 }));
 
 describe("get pipx environments", () => {
@@ -56,7 +56,7 @@ describe("get pipx environments", () => {
 
 describe("ensure pipx path", () => {
   it("should ensure path", async () => {
-    const { addPath } = await import("@actions/core");
+    const { addPath } = await import("gha-utils");
     const { binDir, ensurePath } = await import("./environment.js");
 
     jest.mocked(addPath).mockReset();

--- a/lib/pipx-install-action/src/pipx/environment.ts
+++ b/lib/pipx-install-action/src/pipx/environment.ts
@@ -1,6 +1,6 @@
-import * as core from "@actions/core";
 import { getExecOutput } from "@actions/exec";
 import { getErrorMessage } from "catched-error-message";
+import { addPath } from "gha-utils";
 import os from "os";
 import path from "path";
 
@@ -23,5 +23,5 @@ export async function getEnvironment(env: string): Promise<string> {
 }
 
 export function ensurePath() {
-  core.addPath(binDir);
+  addPath(binDir);
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@actions/core": "^1.10.1",
-    "catched-error-message": "^0.0.1",
+    "gha-utils": "^0.2.0",
     "pipx-install-action": "workspace:^"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,13 @@
-import * as core from "@actions/core";
-import { getErrorMessage } from "catched-error-message";
+import { getInput, logError } from "gha-utils";
 import { pipxInstallAction } from "pipx-install-action";
 
 try {
-  const pkgs = core
-    .getInput("packages", { required: true })
+  const pkgs = getInput("packages")
     .split(/(\s+)/)
     .filter((pkg) => pkg.trim().length > 0);
 
   await pipxInstallAction(...pkgs);
 } catch (err) {
-  core.setFailed(getErrorMessage(err));
+  logError(err);
+  process.exit(1);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2736,6 +2736,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gha-utils@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "gha-utils@npm:0.2.0"
+  checksum: 10c0/34e597b9011518c36abbb4bbbfb0ecaf16171e2bafad3a9ddbbdd3c3b2c1234eb8afc06fc84837565afca5e9ca9d48eb62a7238613ab808d8e1c7e0b6651e2c6
+  languageName: node
+  linkType: hard
+
 "glob-parent@npm:^5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
@@ -4314,7 +4321,6 @@ __metadata:
   resolution: "pipx-install-action@workspace:lib/pipx-install-action"
   dependencies:
     "@actions/cache": "npm:^3.2.4"
-    "@actions/core": "npm:^1.10.1"
     "@actions/exec": "npm:^1.1.1"
     "@eslint/js": "npm:^9.9.0"
     "@jest/globals": "npm:^29.7.0"
@@ -4322,6 +4328,7 @@ __metadata:
     "@types/node": "npm:^22.1.0"
     catched-error-message: "npm:^0.0.1"
     eslint: "npm:^9.9.0"
+    gha-utils: "npm:^0.2.0"
     jest: "npm:^29.7.0"
     jest-extended: "npm:^4.0.2"
     prettier: "npm:^3.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@actions/core@npm:^1.10.0, @actions/core@npm:^1.10.1, @actions/core@npm:^1.2.6":
+"@actions/core@npm:^1.10.0, @actions/core@npm:^1.2.6":
   version: 1.10.1
   resolution: "@actions/core@npm:1.10.1"
   dependencies:
@@ -4539,12 +4539,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root@workspace:."
   dependencies:
-    "@actions/core": "npm:^1.10.1"
     "@eslint/js": "npm:^9.9.0"
     "@types/node": "npm:^22.1.0"
     "@vercel/ncc": "npm:^0.38.1"
-    catched-error-message: "npm:^0.0.1"
     eslint: "npm:^9.9.0"
+    gha-utils: "npm:^0.2.0"
     pipx-install-action: "workspace:^"
     prettier: "npm:^3.3.3"
     typescript: "npm:^5.5.4"


### PR DESCRIPTION
This pull request resolves #256 by utilizing functions from the [GitHub Actions Utilities](https://www.npmjs.com/package/gha-utils) package and effectively removes the [@actions/core](https://www.npmjs.com/package/@actions/core) and [catched-error-message](https://www.npmjs.com/package/catched-error-message) packages from the dependencies.