### PR TITLE
Fix Cannot Spawn Pipx on Ubuntu and macOS

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -82283,6 +82283,7 @@ async function installPackage(pkg) {
         const pipx = (0,external_node_child_process_namespaceObject.spawn)("pipx", ["install", pkg], {
             stdio: "inherit",
             env: {
+                PATH: process.env["PATH"],
                 PIPX_HOME: homeDir,
                 PIPX_BIN_DIR: binDir,
             },

--- a/lib/pipx-install-action/src/pipx/install.test.ts
+++ b/lib/pipx-install-action/src/pipx/install.test.ts
@@ -23,6 +23,7 @@ jest.unstable_mockModule("node:child_process", () => ({
       {
         stdio: "inherit",
         env: {
+          PATH: process.env.PATH,
           PIPX_HOME: homeDir,
           PIPX_BIN_DIR: binDir,
         },

--- a/lib/pipx-install-action/src/pipx/install.ts
+++ b/lib/pipx-install-action/src/pipx/install.ts
@@ -7,6 +7,7 @@ export async function installPackage(pkg: string): Promise<void> {
     const pipx = spawn("pipx", ["install", pkg], {
       stdio: "inherit",
       env: {
+        PATH: process.env["PATH"],
         PIPX_HOME: homeDir,
         PIPX_BIN_DIR: binDir,
       },


### PR DESCRIPTION
This pull request resolves #289 by fixing the `installPackage` function to properly spawn the `pipx` program on Ubuntu and macOS. It addresses the issue by passing the current process's `PATH` when spawning the `pipx` program, ensuring it can locate the `pipx` executable and resolve the issue.