### PR TITLE
Trim Get Environment Function Output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -82238,7 +82238,7 @@ async function getEnvironment(env) {
                 reject(new Error(`Failed to get ${env}: ${err.message}`));
             }
             else {
-                resolve(stdout);
+                resolve(stdout.trim());
             }
         });
     });

--- a/lib/pipx-install-action/src/pipx/environment.test.ts
+++ b/lib/pipx-install-action/src/pipx/environment.test.ts
@@ -35,7 +35,7 @@ jest.unstable_mockModule("node:child_process", () => ({
       ]);
 
       if (args[2] === "AN_ENVIRONMENT") {
-        callback(null, "a value");
+        callback(null, "  a value\n");
       } else {
         callback(new Error("unknown environment"));
       }

--- a/lib/pipx-install-action/src/pipx/environment.ts
+++ b/lib/pipx-install-action/src/pipx/environment.ts
@@ -22,7 +22,7 @@ export async function getEnvironment(env: string): Promise<string> {
         if (err) {
           reject(new Error(`Failed to get ${env}: ${err.message}`));
         } else {
-          resolve(stdout);
+          resolve(stdout.trim());
         }
       },
     );


### PR DESCRIPTION
This pull request resolves #291 by trimming the output of the `getEnvironment` function, preventing it from containing leading whitespaces and newlines.