### PR TITLE
Specify Runner OS Version in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   package-package:
     name: Build Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-package:
     name: Check Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-package:
     name: Test Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4.1.7
@@ -25,11 +25,11 @@ jobs:
 
   test-action:
     name: Test Action
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows, ubuntu, macos]
+        os: [ubuntu-22.04, macos-14, windows-2022]
     steps:
       - name: Checkout Action
         uses: actions/checkout@v4.1.7

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
This pull request resolves #300 by manually specifying the runner OS version to be used in workflows, replacing the default latest version.