### PR TITLE
Fix Add Package Path Function Not Awaiting Add Path

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -510,10 +510,10 @@ async function addPackagePath(pkg) {
     const localVenvs = await getEnvironment("PIPX_LOCAL_VENVS");
     const { name } = parsePackage(pkg);
     if (process.platform === "win32") {
-        addPath(path$1.join(localVenvs, name, "Scripts"));
+        await addPath(path$1.join(localVenvs, name, "Scripts"));
     }
     else {
-        addPath(path$1.join(localVenvs, name, "bin"));
+        await addPath(path$1.join(localVenvs, name, "bin"));
     }
 }
 

--- a/src/pipx/environment.test.ts
+++ b/src/pipx/environment.test.ts
@@ -5,9 +5,13 @@ let sysPaths: string[] = [];
 beforeEach(() => (sysPaths = []));
 
 jest.unstable_mockModule("gha-utils", () => ({
-  addPath: (sysPath: string) => {
-    sysPaths.push(sysPath);
-  },
+  addPath: async (sysPath: string) =>
+    new Promise<void>((resolve) => {
+      setTimeout(() => {
+        sysPaths.push(sysPath);
+        resolve();
+      }, 100);
+    }),
 }));
 
 let homeDir: string;

--- a/src/pipx/environment.ts
+++ b/src/pipx/environment.ts
@@ -39,8 +39,8 @@ export async function addPackagePath(pkg: string): Promise<void> {
   const { name } = parsePackage(pkg);
 
   if (process.platform === "win32") {
-    addPath(path.join(localVenvs, name, "Scripts"));
+    await addPath(path.join(localVenvs, name, "Scripts"));
   } else {
-    addPath(path.join(localVenvs, name, "bin"));
+    await addPath(path.join(localVenvs, name, "bin"));
   }
 }


### PR DESCRIPTION
This pull request resolves #310 by awaiting the call to the `addPath` function in the `addPackagePath` function. It also modifies the tests to mock `addPath` as an asynchronous process.