### PR TITLE
Test Action Entrypoint Script

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -613,5 +613,5 @@ try {
 }
 catch (err) {
     logError(err);
-    process.exit(1);
+    process.exitCode = 1;
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,0 +1,50 @@
+import { jest } from "@jest/globals";
+
+describe("install Python packages", () => {
+  let installedPackages: string[] = [];
+  jest.unstable_mockModule("./lib.js", () => ({
+    pipxInstallAction: (...pkgs: string[]): void => {
+      for (const pkg of pkgs) {
+        if (pkg === "invalid") throw new Error("invalid package");
+        installedPackages.push(pkg);
+      }
+    },
+  }));
+
+  let inputs: Record<string, string | undefined> = {};
+  let loggedError: unknown;
+  jest.unstable_mockModule("gha-utils", () => ({
+    getInput: (name: string): string => {
+      return inputs[name] ?? "";
+    },
+    logError: (err: unknown) => {
+      loggedError = err;
+    },
+  }));
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    installedPackages = [];
+    inputs = {};
+    loggedError = undefined;
+  });
+
+  it("should install packages", async () => {
+    inputs["packages"] = "a-package another-package";
+
+    await import("../src/main.js");
+
+    expect(installedPackages).toEqual(["a-package", "another-package"]);
+    expect(loggedError).toBeUndefined();
+  });
+
+  it("should fail to install an invalid package", async () => {
+    inputs["packages"] = "invalid";
+
+    await import("./main.js");
+
+    expect(installedPackages).toEqual([]);
+    expect(loggedError).toEqual(new Error("invalid package"));
+  });
+});

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -28,6 +28,7 @@ describe("install Python packages", () => {
     installedPackages = [];
     inputs = {};
     loggedError = undefined;
+    process.exitCode = undefined;
   });
 
   it("should install packages", async () => {
@@ -37,6 +38,7 @@ describe("install Python packages", () => {
 
     expect(installedPackages).toEqual(["a-package", "another-package"]);
     expect(loggedError).toBeUndefined();
+    expect(process.exitCode).toBeUndefined();
   });
 
   it("should fail to install an invalid package", async () => {
@@ -46,5 +48,8 @@ describe("install Python packages", () => {
 
     expect(installedPackages).toEqual([]);
     expect(loggedError).toEqual(new Error("invalid package"));
+    expect(process.exitCode).toBe(1);
+
+    process.exitCode = undefined;
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,5 +9,5 @@ try {
   await pipxInstallAction(...pkgs);
 } catch (err) {
   logError(err);
-  process.exit(1);
+  process.exitCode = 1;
 }


### PR DESCRIPTION
This pull request resolves #316 by adding tests for the action entrypoint script in `src/main.ts`. It also modifies the script to specify the exit code, rather than directly invoking the `exit` function, allowing resources to be cleaned up before the process exits.