### PR TITLE
Automatically Add Package Path After Restoring and Installing Packages

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -532,7 +532,10 @@ async function savePipxPackageCache(pkg) {
 async function restorePipxPackageCache(pkg) {
     try {
         const { name, version } = parsePipxPackage(pkg);
-        return await restoreCache(`pipx-${process.platform}-${name}`, version);
+        const restored = await restoreCache(`pipx-${process.platform}-${name}`, version);
+        if (restored)
+            await addPipxPackagePath(pkg);
+        return restored;
     }
     catch (err) {
         throw new Error(`Failed to restore ${pkg} cache: ${r(err)}`);
@@ -572,8 +575,6 @@ async function pipxInstallAction(...pkgs) {
         logInfo(`Restoring \u001b[34m${pkg}\u001b[39m cache...`);
         try {
             cacheFound = await restorePipxPackageCache(pkg);
-            if (cacheFound)
-                await addPipxPackagePath(pkg);
         }
         catch (err) {
             logError(`Failed to restore ${pkg} cache: ${r(err)}`);

--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -559,6 +559,7 @@ async function installPipxPackage(pkg) {
                 }
             });
         });
+        await addPipxPackagePath(pkg);
     }
     catch (err) {
         throw new Error(`Failed to install ${pkg}: ${r(err)}`);
@@ -583,7 +584,6 @@ async function pipxInstallAction(...pkgs) {
             beginLogGroup(`Cache not found, installing \u001b[34m${pkg}\u001b[39m...`);
             try {
                 await installPipxPackage(pkg);
-                await addPipxPackagePath(pkg);
             }
             catch (err) {
                 endLogGroup();

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -25,10 +25,6 @@ jest.unstable_mockModule("./pipx/cache.js", () => ({
   savePipxPackageCache: jest.fn(),
 }));
 
-jest.unstable_mockModule("./pipx/environment.js", () => ({
-  addPipxPackagePath: jest.fn(),
-}));
-
 jest.unstable_mockModule("./pipx/install.js", () => ({
   installPipxPackage: jest.fn(),
 }));
@@ -37,20 +33,14 @@ describe("install Python packages action", () => {
   beforeEach(async () => {
     const [
       { restorePipxPackageCache, savePipxPackageCache },
-      { addPipxPackagePath },
       { installPipxPackage },
     ] = await Promise.all([
       import("./pipx/cache.js"),
-      import("./pipx/environment.js"),
       import("./pipx/install.js"),
     ]);
 
     logs = [];
     failed = false;
-
-    jest.mocked(addPipxPackagePath).mockImplementation(async (pkg) => {
-      logs.push(`${pkg} path added`);
-    });
 
     jest.mocked(installPipxPackage).mockImplementation(async (pkg) => {
       logs.push(`${pkg} installed`);
@@ -81,7 +71,6 @@ describe("install Python packages action", () => {
     expect(logs).toStrictEqual([
       "Restoring \u001b[34many-pkg\u001b[39m cache...",
       "any-pkg cache found",
-      "any-pkg path added",
     ]);
   });
 

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -96,7 +96,6 @@ describe("install Python packages action", () => {
       "any-pkg cache not found",
       "::group::Cache not found, installing \u001b[34many-pkg\u001b[39m...",
       "any-pkg installed",
-      "any-pkg path added",
       "::endgroup::",
       "Saving \u001b[34many-pkg\u001b[39m cache...",
       "any-pkg cache saved",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -23,7 +23,6 @@ export async function pipxInstallAction(...pkgs: string[]): Promise<void> {
       );
       try {
         await installPipxPackage(pkg);
-        await addPipxPackagePath(pkg);
       } catch (err) {
         endLogGroup();
         logError(`Failed to install ${pkg}: ${getErrorMessage(err)}`);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,7 +1,6 @@
 import { getErrorMessage } from "catched-error-message";
 import { beginLogGroup, endLogGroup, logError, logInfo } from "gha-utils";
 import { restorePipxPackageCache, savePipxPackageCache } from "./pipx/cache.js";
-import { addPipxPackagePath } from "./pipx/environment.js";
 import { installPipxPackage } from "./pipx/install.js";
 
 export async function pipxInstallAction(...pkgs: string[]): Promise<void> {
@@ -10,7 +9,6 @@ export async function pipxInstallAction(...pkgs: string[]): Promise<void> {
     logInfo(`Restoring \u001b[34m${pkg}\u001b[39m cache...`);
     try {
       cacheFound = await restorePipxPackageCache(pkg);
-      if (cacheFound) await addPipxPackagePath(pkg);
     } catch (err) {
       logError(`Failed to restore ${pkg} cache: ${getErrorMessage(err)}`);
       process.exitCode = 1;

--- a/src/pipx/cache.ts
+++ b/src/pipx/cache.ts
@@ -1,6 +1,6 @@
 import { restoreCache, saveCache } from "cache-action";
 import { getErrorMessage } from "catched-error-message";
-import { getPipxEnvironment } from "./environment.js";
+import { addPipxPackagePath, getPipxEnvironment } from "./environment.js";
 import path from "path";
 import { parsePipxPackage } from "./utils.js";
 
@@ -20,7 +20,12 @@ export async function savePipxPackageCache(pkg: string): Promise<void> {
 export async function restorePipxPackageCache(pkg: string): Promise<boolean> {
   try {
     const { name, version } = parsePipxPackage(pkg);
-    return await restoreCache(`pipx-${process.platform}-${name}`, version);
+    const restored = await restoreCache(
+      `pipx-${process.platform}-${name}`,
+      version,
+    );
+    if (restored) await addPipxPackagePath(pkg);
+    return restored;
   } catch (err) {
     throw new Error(`Failed to restore ${pkg} cache: ${getErrorMessage(err)}`);
   }

--- a/src/pipx/install.ts
+++ b/src/pipx/install.ts
@@ -1,6 +1,6 @@
 import { getErrorMessage } from "catched-error-message";
 import { spawn } from "node:child_process";
-import { homeDir } from "./environment.js";
+import { addPipxPackagePath, homeDir } from "./environment.js";
 
 export async function installPipxPackage(pkg: string): Promise<void> {
   try {
@@ -21,6 +21,7 @@ export async function installPipxPackage(pkg: string): Promise<void> {
         }
       });
     });
+    await addPipxPackagePath(pkg);
   } catch (err) {
     throw new Error(`Failed to install ${pkg}: ${getErrorMessage(err)}`);
   }


### PR DESCRIPTION
This pull request resolves #319 by modifying the `restorePipxPackageCache` and `installPipxPackage` functions to call the `addPipxPackagePath` function after restoring the cache and installing the package. It also updates the tests accordingly.