### PR TITLE
Use Default Pipx Home Directory

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -4,7 +4,6 @@ import os from 'node:os';
 import path from 'node:path';
 import https from 'node:https';
 import { spawn, execFile } from 'node:child_process';
-import os$1 from 'os';
 import path$1 from 'path';
 
 /**
@@ -481,15 +480,9 @@ function parsePipxPackage(pkg) {
     };
 }
 
-const homeDir = path$1.join(os$1.homedir(), ".local/pipx");
 async function getPipxEnvironment(env) {
     return new Promise((resolve, reject) => {
-        execFile("pipx", ["environment", "--value", env], {
-            env: {
-                PATH: process.env["PATH"],
-                PIPX_HOME: homeDir,
-            },
-        }, (err, stdout) => {
+        execFile("pipx", ["environment", "--value", env], { env: { PATH: process.env["PATH"] } }, (err, stdout) => {
             if (err) {
                 reject(new Error(`Failed to get ${env}: ${err.message}`));
             }
@@ -547,10 +540,7 @@ async function installPipxPackage(pkg) {
     try {
         const pipx = spawn("pipx", ["install", pkg], {
             stdio: "inherit",
-            env: {
-                PATH: process.env["PATH"],
-                PIPX_HOME: homeDir,
-            },
+            env: { PATH: process.env["PATH"] },
         });
         await new Promise((resolve, reject) => {
             pipx.on("error", reject);

--- a/src/pipx/environment.test.ts
+++ b/src/pipx/environment.test.ts
@@ -14,12 +14,6 @@ jest.unstable_mockModule("gha-utils", () => ({
     }),
 }));
 
-let homeDir: string;
-beforeAll(async () => {
-  const env = await import("./environment.js");
-  homeDir = env.homeDir;
-});
-
 jest.unstable_mockModule("node:child_process", () => ({
   execFile: (
     file: string,
@@ -32,12 +26,7 @@ jest.unstable_mockModule("node:child_process", () => ({
         "pipx",
         3,
         ["environment", "--value"],
-        {
-          env: {
-            PATH: process.env["PATH"],
-            PIPX_HOME: homeDir,
-          },
-        },
+        { env: { PATH: process.env["PATH"] } },
       ]);
 
       if (args[2] === "AN_ENVIRONMENT") {

--- a/src/pipx/environment.ts
+++ b/src/pipx/environment.ts
@@ -1,22 +1,14 @@
 import { addPath } from "gha-utils";
 import { execFile } from "node:child_process";
-import os from "os";
 import path from "path";
 import { parsePipxPackage } from "./utils.js";
-
-export const homeDir = path.join(os.homedir(), ".local/pipx");
 
 export async function getPipxEnvironment(env: string): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     execFile(
       "pipx",
       ["environment", "--value", env],
-      {
-        env: {
-          PATH: process.env["PATH"],
-          PIPX_HOME: homeDir,
-        },
-      },
+      { env: { PATH: process.env["PATH"] } },
       (err, stdout) => {
         if (err) {
           reject(new Error(`Failed to get ${env}: ${err.message}`));

--- a/src/pipx/install.test.ts
+++ b/src/pipx/install.test.ts
@@ -21,10 +21,7 @@ jest.unstable_mockModule("node:child_process", () => ({
       "install",
       {
         stdio: "inherit",
-        env: {
-          PATH: process.env.PATH,
-          PIPX_HOME: "a-home-dir",
-        },
+        env: { PATH: process.env.PATH },
       },
     ]);
 
@@ -41,7 +38,6 @@ jest.unstable_mockModule("./environment.js", () => ({
         resolve();
       }, 100);
     }),
-  homeDir: "a-home-dir",
 }));
 
 describe("install Python packages", () => {

--- a/src/pipx/install.ts
+++ b/src/pipx/install.ts
@@ -1,15 +1,12 @@
 import { getErrorMessage } from "catched-error-message";
 import { spawn } from "node:child_process";
-import { addPipxPackagePath, homeDir } from "./environment.js";
+import { addPipxPackagePath } from "./environment.js";
 
 export async function installPipxPackage(pkg: string): Promise<void> {
   try {
     const pipx = spawn("pipx", ["install", pkg], {
       stdio: "inherit",
-      env: {
-        PATH: process.env["PATH"],
-        PIPX_HOME: homeDir,
-      },
+      env: { PATH: process.env["PATH"] },
     });
     await new Promise<void>((resolve, reject) => {
       pipx.on("error", reject);


### PR DESCRIPTION
This pull request resolves #326 by modifying the action to use the default Pipx home directory. It achieves this by removing the setting of the `PIPX_HOME` environment variable when invoking the Pipx command.