### PR TITLE
Modify Cache Name to Contain Package Version

### DIFF
--- a/src/pipx/cache.test.ts
+++ b/src/pipx/cache.test.ts
@@ -22,7 +22,9 @@ beforeEach(async () => {
 describe("save Python package caches", () => {
   it("should save a package cache", async () => {
     const { saveCache } = await import("cache-action");
-    const { savePipxPackageCache } = await import("./cache.js");
+    const { pipxPackageCacheVersion, savePipxPackageCache } = await import(
+      "./cache.js"
+    );
 
     jest.mocked(saveCache).mockReset();
 
@@ -31,7 +33,7 @@ describe("save Python package caches", () => {
 
     expect(saveCache).toHaveBeenCalledExactlyOnceWith(
       `pipx-${process.platform}-some-package`,
-      "latest",
+      pipxPackageCacheVersion,
       ["/path/to/venvs/some-package"],
     );
   });
@@ -57,7 +59,9 @@ describe("save Python package caches", () => {
 describe("restore Python package caches", () => {
   it("should restore a saved package cache", async () => {
     const { restoreCache } = await import("cache-action");
-    const { restorePipxPackageCache } = await import("./cache.js");
+    const { pipxPackageCacheVersion, restorePipxPackageCache } = await import(
+      "./cache.js"
+    );
     const { addPipxPackagePath } = await import("./environment.js");
 
     jest.mocked(restoreCache).mockReset().mockResolvedValue(true);
@@ -68,7 +72,7 @@ describe("restore Python package caches", () => {
 
     expect(restoreCache).toHaveBeenCalledExactlyOnceWith(
       `pipx-${process.platform}-some-package`,
-      "latest",
+      pipxPackageCacheVersion,
     );
 
     expect(addPipxPackagePath).toHaveBeenCalledExactlyOnceWith("some-package");
@@ -76,7 +80,9 @@ describe("restore Python package caches", () => {
 
   it("should restore an unsaved package cache", async () => {
     const { restoreCache } = await import("cache-action");
-    const { restorePipxPackageCache } = await import("./cache.js");
+    const { pipxPackageCacheVersion, restorePipxPackageCache } = await import(
+      "./cache.js"
+    );
     const { addPipxPackagePath } = await import("./environment.js");
 
     jest.mocked(restoreCache).mockReset().mockResolvedValue(false);
@@ -87,7 +93,7 @@ describe("restore Python package caches", () => {
 
     expect(restoreCache).toHaveBeenCalledExactlyOnceWith(
       `pipx-${process.platform}-some-package`,
-      "latest",
+      pipxPackageCacheVersion,
     );
 
     expect(addPipxPackagePath).toHaveBeenCalledTimes(0);

--- a/src/pipx/cache.ts
+++ b/src/pipx/cache.ts
@@ -4,14 +4,17 @@ import { addPipxPackagePath, getPipxEnvironment } from "./environment.js";
 import path from "path";
 import { parsePipxPackage } from "./utils.js";
 
+export const pipxPackageCacheVersion = "pipx-install-action-2.0.0";
+
 export async function savePipxPackageCache(pkg: string): Promise<void> {
   try {
     const localVenvs = await getPipxEnvironment("PIPX_LOCAL_VENVS");
-    const { name, version } = parsePipxPackage(pkg);
-
-    await saveCache(`pipx-${process.platform}-${name}`, version, [
-      path.join(localVenvs, name),
-    ]);
+    const { name } = parsePipxPackage(pkg);
+    await saveCache(
+      `pipx-${process.platform}-${pkg}`,
+      pipxPackageCacheVersion,
+      [path.join(localVenvs, name)],
+    );
   } catch (err) {
     throw new Error(`Failed to save ${pkg} cache: ${getErrorMessage(err)}`);
   }
@@ -19,10 +22,9 @@ export async function savePipxPackageCache(pkg: string): Promise<void> {
 
 export async function restorePipxPackageCache(pkg: string): Promise<boolean> {
   try {
-    const { name, version } = parsePipxPackage(pkg);
     const restored = await restoreCache(
-      `pipx-${process.platform}-${name}`,
-      version,
+      `pipx-${process.platform}-${pkg}`,
+      pipxPackageCacheVersion,
     );
     if (restored) await addPipxPackagePath(pkg);
     return restored;


### PR DESCRIPTION
This pull request resolves #331 by modifying the pipx package cache name to include the package version and setting the cache version to a static string with the value `pipx-install-action-2.0.0`.