### PR TITLE
Bump Node to Version 23.10.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=20.17.0
+use-node-version=23.10.0


### PR DESCRIPTION
This pull request bumps the Node version specified in the `.npmrc` file to version [23.10.0](https://github.com/nodejs/node/releases/tag/v23.10.0).