### PR TITLE
Configure TypeScript to Cover All Files

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -24,5 +24,8 @@ jobs:
       - name: Check Diff
         run: git diff && git diff-index --quiet --exit-code HEAD
 
+      - name: Check Types
+        run: pnpm tsc
+
       - name: Check Lint
         run: pnpm lint

--- a/src/pipx/utils.test.ts
+++ b/src/pipx/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parsePipxPackage } from "./utils";
+import { parsePipxPackage } from "./utils.js";
 
 describe("parse name and version of Pipx packages from package strings", () => {
   it("should parse from a package string with a version specifier", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "@tsconfig/node23",
-  "include": ["src"],
-  "exclude": ["**/*.test.*"],
   "compilerOptions": {
-    "outDir": "dist"
+    "noEmit": true
   }
 }


### PR DESCRIPTION
This pull request resolves #602 by modifying the TypeScript configuration to cover all files. This change also added a new Check Types step in the `check` workflow.