### PR TITLE
Remove Upload Artifact Steps in CI Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,12 +21,6 @@ jobs:
       - name: Build Package
         run: pnpm build --out package.tgz
 
-      - name: Upload Package
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: package
-          path: package.tgz
-
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-24.04
@@ -42,9 +36,3 @@ jobs:
 
       - name: Build Documentation
         run: pnpm build:docs
-
-      - name: Upload Documentation
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: docs
-          path: docs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
         run: pnpm install
 
       - name: Build Package
-        run: pnpm build --out package.tgz
+        run: pnpm build
 
   build-docs:
     name: Build Documentation

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ dist/lib.*
 docs/
 node_modules/
 
-package.tgz
+*.tgz


### PR DESCRIPTION
This pull request resolves #604 by removing the upload artifact steps from the `build` workflow. This change also modify the `build` workflow to build the package with a default tarball name.