### PR TITLE
Modify TypeDoc Configuration to Specify Source Files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,4 +35,4 @@ jobs:
         run: pnpm install
 
       - name: Build Documentation
-        run: pnpm typedoc src/lib.ts
+        run: pnpm typedoc

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
         run: pnpm install
 
       - name: Build Documentation
-        run: pnpm typedoc src/lib.ts
+        run: pnpm typedoc
 
       - name: Upload Documentation
         uses: actions/upload-pages-artifact@v3.0.1

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,7 +24,7 @@ pre-commit:
       run: pnpm eslint --no-warn-ignored --fix {staged_files}
 
     - name: check documentation
-      run: pnpm typedoc src/lib.ts --emit none
+      run: pnpm typedoc --emit none
       glob:
         - src/*.ts
         - .npmrc

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,3 +1,4 @@
 {
+  "entryPoints": ["src/lib.ts"],
   "highlightLanguages": ["bash", "js", "yaml"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,4 +1,3 @@
 {
-  "entryPoints": ["src/lib.ts"],
-  "highlightLanguages": ["bash", "js", "yaml"]
+  "entryPoints": ["src/lib.ts"]
 }


### PR DESCRIPTION
This pull request resolves #611 by modifying the `typedoc.json` configuration file to specify the source files entrypoint using the `entryPoints` option. It also removes the unused `highlightLanguages` options in the configuration.