### PR TITLE
Bump Node.js to Version 20.19.3

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=20.17.0
+use-node-version=20.19.3


### PR DESCRIPTION
This pull request bumps the Node.js version specified in the `.npmrc` file to version [20.19.3](https://github.com/nodejs/node/releases/tag/v20.19.3).