### PR TITLE
Strict TypeScript ESLint configuration

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -243,19 +243,19 @@ async function saveCache(key, version, filePaths) {
  * @throws An error if the package string cannot be parsed.
  */
 function parsePipxPackage(pkg) {
-    const match = pkg.match(/^([\w\d._-]+)(==([\d.]+))?$/);
+    const match = /^([\w\d._-]+)(==([\d.]+))?$/.exec(pkg);
     if (match == null || match.length < 2) {
         throw new Error(`unable to parse package name and version from: ${pkg}`);
     }
     return {
         name: match[1],
-        version: match[3] ?? "latest",
+        version: match[3] || "latest",
     };
 }
 
 async function getPipxEnvironment(env) {
     return new Promise((resolve, reject) => {
-        execFile("pipx", ["environment", "--value", env], { env: { PATH: process.env["PATH"] } }, (err, stdout) => {
+        execFile("pipx", ["environment", "--value", env], { env: { PATH: process.env.PATH } }, (err, stdout) => {
             if (err) {
                 reject(new Error(`Failed to get ${env}: ${err.message}`));
             }
@@ -311,7 +311,7 @@ async function installPipxPackage(pkg) {
     try {
         const pipx = spawn("pipx", ["install", pkg], {
             stdio: "inherit",
-            env: { PATH: process.env["PATH"] },
+            env: { PATH: process.env.PATH },
         });
         await new Promise((resolve, reject) => {
             pipx.on("error", reject);
@@ -320,7 +320,10 @@ async function installPipxPackage(pkg) {
                     resolve();
                 }
                 else {
-                    reject(new Error(`process exited with code: ${code}`));
+                    let message = "process exited";
+                    if (code !== null)
+                        message += ` with code: ${code.toString()}`;
+                    reject(new Error(message));
                 }
             });
         });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,17 +1,20 @@
 import eslint from "@eslint/js";
+import { globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
-export default [
+export default tseslint.config(
+  globalIgnores(["dist", "docs"]),
   eslint.configs.recommended,
-  ...tseslint.configs.recommended,
-  ...tseslint.configs.stylistic,
+  tseslint.configs.strictTypeChecked,
+  tseslint.configs.stylisticTypeChecked,
   {
-    ignores: [".*", "dist", "docs"],
-  },
-  {
-    files: ["**/*.test.ts"],
-    rules: {
-      "@typescript-eslint/no-explicit-any": "off",
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["eslint.config.js", "rollup.config.js"],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
   },
-];
+);

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -11,7 +11,7 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ["eslint.config.js", "rollup.config.js"],
+          allowDefaultProject: ["rollup.config.js"],
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/node": "^22.14.1",
     "@vitest/coverage-v8": "^3.0.8",
     "eslint": "^9.24.0",
+    "jiti": "^2.4.2",
     "prettier": "^3.5.3",
     "rollup": "^4.39.0",
     "rollup-plugin-ts": "^3.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,10 +38,13 @@ importers:
         version: 22.14.1
       '@vitest/coverage-v8':
         specifier: ^3.0.8
-        version: 3.0.8(vitest@3.0.8(@types/node@22.14.1)(yaml@2.8.0))
+        version: 3.0.8(vitest@3.0.8(@types/node@22.14.1)(jiti@2.4.2)(yaml@2.8.0))
       eslint:
         specifier: ^9.24.0
-        version: 9.24.0
+        version: 9.24.0(jiti@2.4.2)
+      jiti:
+        specifier: ^2.4.2
+        version: 2.4.2
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -62,10 +65,10 @@ importers:
         version: 5.8.3
       typescript-eslint:
         specifier: ^8.29.1
-        version: 8.29.1(eslint@9.24.0)(typescript@5.8.3)
+        version: 8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/node@22.14.1)(yaml@2.8.0)
+        version: 3.0.8(@types/node@22.14.1)(jiti@2.4.2)(yaml@2.8.0)
 
 packages:
 
@@ -1062,6 +1065,10 @@ packages:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1702,14 +1709,14 @@ snapshots:
   '@esbuild/win32-x64@0.25.0':
     optional: true
 
-  '@eslint-community/eslint-utils@4.5.1(eslint@9.24.0)':
+  '@eslint-community/eslint-utils@4.5.1(eslint@9.24.0(jiti@2.4.2))':
     dependencies:
-      eslint: 9.24.0
+      eslint: 9.24.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.6.0(eslint@9.24.0)':
+  '@eslint-community/eslint-utils@4.6.0(eslint@9.24.0(jiti@2.4.2))':
     dependencies:
-      eslint: 9.24.0
+      eslint: 9.24.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -1987,15 +1994,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@8.29.1(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.29.1(eslint@9.24.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.29.1
-      '@typescript-eslint/type-utils': 8.29.1(eslint@9.24.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.29.1(eslint@9.24.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.29.1
-      eslint: 9.24.0
+      eslint: 9.24.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -2004,14 +2011,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.29.1(eslint@9.24.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.29.1
       '@typescript-eslint/types': 8.29.1
       '@typescript-eslint/typescript-estree': 8.29.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.29.1
       debug: 4.4.0
-      eslint: 9.24.0
+      eslint: 9.24.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -2021,12 +2028,12 @@ snapshots:
       '@typescript-eslint/types': 8.29.1
       '@typescript-eslint/visitor-keys': 8.29.1
 
-  '@typescript-eslint/type-utils@8.29.1(eslint@9.24.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.29.1(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.29.1(eslint@9.24.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
       debug: 4.4.0
-      eslint: 9.24.0
+      eslint: 9.24.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -2048,13 +2055,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.29.1(eslint@9.24.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.0(eslint@9.24.0)
+      '@eslint-community/eslint-utils': 4.6.0(eslint@9.24.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.29.1
       '@typescript-eslint/types': 8.29.1
       '@typescript-eslint/typescript-estree': 8.29.1(typescript@5.8.3)
-      eslint: 9.24.0
+      eslint: 9.24.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -2064,7 +2071,7 @@ snapshots:
       '@typescript-eslint/types': 8.29.1
       eslint-visitor-keys: 4.2.0
 
-  '@vitest/coverage-v8@3.0.8(vitest@3.0.8(@types/node@22.14.1)(yaml@2.8.0))':
+  '@vitest/coverage-v8@3.0.8(vitest@3.0.8(@types/node@22.14.1)(jiti@2.4.2)(yaml@2.8.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -2078,7 +2085,7 @@ snapshots:
       std-env: 3.8.1
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.8(@types/node@22.14.1)(yaml@2.8.0)
+      vitest: 3.0.8(@types/node@22.14.1)(jiti@2.4.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2089,13 +2096,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.8(vite@6.2.1(@types/node@22.14.1)(yaml@2.8.0))':
+  '@vitest/mocker@3.0.8(vite@6.2.1(@types/node@22.14.1)(jiti@2.4.2)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.0.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.1(@types/node@22.14.1)(yaml@2.8.0)
+      vite: 6.2.1(@types/node@22.14.1)(jiti@2.4.2)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.0.8':
     dependencies:
@@ -2307,9 +2314,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint@9.24.0:
+  eslint@9.24.0(jiti@2.4.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@9.24.0)
+      '@eslint-community/eslint-utils': 4.5.1(eslint@9.24.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.20.0
       '@eslint/config-helpers': 0.2.1
@@ -2344,6 +2351,8 @@ snapshots:
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2556,6 +2565,8 @@ snapshots:
       ci-info: 3.9.0
       graceful-fs: 4.2.11
       picomatch: 2.3.1
+
+  jiti@2.4.2: {}
 
   js-tokens@4.0.0: {}
 
@@ -2908,12 +2919,12 @@ snapshots:
       typescript: 5.8.3
       yaml: 2.8.0
 
-  typescript-eslint@8.29.1(eslint@9.24.0)(typescript@5.8.3):
+  typescript-eslint@8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.29.1(@typescript-eslint/parser@8.29.1(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.29.1(eslint@9.24.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.29.1(eslint@9.24.0)(typescript@5.8.3)
-      eslint: 9.24.0
+      '@typescript-eslint/eslint-plugin': 8.29.1(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
+      eslint: 9.24.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -2936,13 +2947,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.0.8(@types/node@22.14.1)(yaml@2.8.0):
+  vite-node@3.0.8(@types/node@22.14.1)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.1(@types/node@22.14.1)(yaml@2.8.0)
+      vite: 6.2.1(@types/node@22.14.1)(jiti@2.4.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2957,7 +2968,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.1(@types/node@22.14.1)(yaml@2.8.0):
+  vite@6.2.1(@types/node@22.14.1)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3
@@ -2965,12 +2976,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.14.1
       fsevents: 2.3.3
+      jiti: 2.4.2
       yaml: 2.8.0
 
-  vitest@3.0.8(@types/node@22.14.1)(yaml@2.8.0):
+  vitest@3.0.8(@types/node@22.14.1)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 3.0.8
-      '@vitest/mocker': 3.0.8(vite@6.2.1(@types/node@22.14.1)(yaml@2.8.0))
+      '@vitest/mocker': 3.0.8(vite@6.2.1(@types/node@22.14.1)(jiti@2.4.2)(yaml@2.8.0))
       '@vitest/pretty-format': 3.0.8
       '@vitest/runner': 3.0.8
       '@vitest/snapshot': 3.0.8
@@ -2986,8 +2998,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.1(@types/node@22.14.1)(yaml@2.8.0)
-      vite-node: 3.0.8(@types/node@22.14.1)(yaml@2.8.0)
+      vite: 6.2.1(@types/node@22.14.1)(jiti@2.4.2)(yaml@2.8.0)
+      vite-node: 3.0.8(@types/node@22.14.1)(jiti@2.4.2)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.14.1

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -99,7 +99,7 @@ describe("install Python packages", () => {
   });
 
   it("should fail to restore a package cache", async () => {
-    inputs["packages"] = "a-package";
+    inputs.packages = "a-package";
 
     vi.mocked(restorePipxPackageCache).mockRejectedValue(
       new Error("unknown error"),
@@ -118,7 +118,7 @@ describe("install Python packages", () => {
   });
 
   it("should fail to install a package", async () => {
-    inputs["packages"] = "a-package";
+    inputs.packages = "a-package";
 
     vi.mocked(installPipxPackage).mockRejectedValue(new Error("unknown error"));
 
@@ -137,7 +137,7 @@ describe("install Python packages", () => {
   });
 
   it("should fail to save a package cache", async () => {
-    inputs["packages"] = "a-package";
+    inputs.packages = "a-package";
 
     vi.mocked(savePipxPackageCache).mockRejectedValue(
       new Error("unknown error"),
@@ -159,7 +159,7 @@ describe("install Python packages", () => {
   });
 
   it("should install packages and save the cache", async () => {
-    inputs["packages"] = "a-package another-package";
+    inputs.packages = "a-package another-package";
 
     await import("../src/main.js");
 
@@ -180,7 +180,7 @@ describe("install Python packages", () => {
   });
 
   it("should restore packages", async () => {
-    inputs["packages"] = "a-package another-package";
+    inputs.packages = "a-package another-package";
     cachedPackages = ["a-package", "another-package"];
 
     await import("../src/main.js");

--- a/src/pipx/cache.test.ts
+++ b/src/pipx/cache.test.ts
@@ -20,9 +20,12 @@ vi.mock("./environment.js", () => ({
 }));
 
 beforeEach(() => {
-  vi.mocked(getPipxEnvironment).mockImplementation(async (env) => {
-    return env === "PIPX_LOCAL_VENVS" ? "/path/to/venvs" : "";
-  });
+  vi.mocked(getPipxEnvironment).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async (env) => {
+      return env === "PIPX_LOCAL_VENVS" ? "/path/to/venvs" : "";
+    },
+  );
 });
 
 describe("save Python package caches", () => {

--- a/src/pipx/environment.test.ts
+++ b/src/pipx/environment.test.ts
@@ -19,15 +19,15 @@ vi.mock("node:child_process", () => ({
   execFile: (
     file: string,
     args: string[],
-    options: any,
-    callback: (...args: any[]) => void,
+    options: unknown,
+    callback: (error: unknown, stdout?: string, stderr?: string) => void,
   ) => {
     try {
       expect([file, args.length, args.slice(0, 2), options]).toEqual([
         "pipx",
         3,
         ["environment", "--value"],
-        { env: { PATH: process.env["PATH"] } },
+        { env: { PATH: process.env.PATH } },
       ]);
 
       if (args[2] === "AN_ENVIRONMENT") {

--- a/src/pipx/environment.ts
+++ b/src/pipx/environment.ts
@@ -8,7 +8,7 @@ export async function getPipxEnvironment(env: string): Promise<string> {
     execFile(
       "pipx",
       ["environment", "--value", env],
-      { env: { PATH: process.env["PATH"] } },
+      { env: { PATH: process.env.PATH } },
       (err, stdout) => {
         if (err) {
           reject(new Error(`Failed to get ${env}: ${err.message}`));

--- a/src/pipx/install.test.ts
+++ b/src/pipx/install.test.ts
@@ -2,13 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { installPipxPackage } from "./install.js";
 
 class ChildProcess {
-  #events: Record<string, any[] | undefined> = {};
+  #events: Record<string, unknown[] | undefined> = {};
 
-  constructor(events: Record<string, any[]>) {
+  constructor(events: Record<string, unknown[]>) {
     this.#events = events;
   }
 
-  on(event: string, callback: (...args: any[]) => any): void {
+  on(event: string, callback: (...args: unknown[]) => unknown): void {
     const args = this.#events[event];
     if (args !== undefined) callback(...args);
   }

--- a/src/pipx/install.ts
+++ b/src/pipx/install.ts
@@ -6,7 +6,7 @@ export async function installPipxPackage(pkg: string): Promise<void> {
   try {
     const pipx = spawn("pipx", ["install", pkg], {
       stdio: "inherit",
-      env: { PATH: process.env["PATH"] },
+      env: { PATH: process.env.PATH },
     });
     await new Promise<void>((resolve, reject) => {
       pipx.on("error", reject);
@@ -14,7 +14,9 @@ export async function installPipxPackage(pkg: string): Promise<void> {
         if (code === 0) {
           resolve();
         } else {
-          reject(new Error(`process exited with code: ${code}`));
+          let message = "process exited";
+          if (code !== null) message += ` with code: ${code.toString()}`;
+          reject(new Error(message));
         }
       });
     });

--- a/src/pipx/utils.ts
+++ b/src/pipx/utils.ts
@@ -9,13 +9,13 @@ export function parsePipxPackage(pkg: string): {
   name: string;
   version: string;
 } {
-  const match = pkg.match(/^([\w\d._-]+)(==([\d.]+))?$/);
+  const match = /^([\w\d._-]+)(==([\d.]+))?$/.exec(pkg);
   if (match == null || match.length < 2) {
     throw new Error(`unable to parse package name and version from: ${pkg}`);
   }
 
   return {
     name: match[1],
-    version: match[3] ?? "latest",
+    version: match[3] || "latest",
   };
 }


### PR DESCRIPTION
This pull request resolves #616 by enabling a stricter TypeScript configuration. This change also convert the ESLint configuration to TypeScript.