### PR TITLE
Remove tslib From Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "prettier": "^3.6.2",
     "rollup": "^4.39.0",
     "rollup-plugin-ts": "^3.4.5",
-    "tslib": "^2.8.1",
     "typedoc": "^0.28.7",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.35.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,6 @@ importers:
       rollup-plugin-ts:
         specifier: ^3.4.5
         version: 3.4.5(rollup@4.39.0)(typescript@5.8.3)
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       typedoc:
         specifier: ^0.28.7
         version: 0.28.7(typescript@5.8.3)


### PR DESCRIPTION
This pull request resolves #643 by removing the unused tslib package from the dependencies in this project.