### PR TITLE
Reorder Steps for Checking and Testing the Project

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -18,11 +18,11 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
-      - name: Check Formatting
-        run: pnpm prettier --check .
-
       - name: Check Types
         run: pnpm tsc
+
+      - name: Check Formatting
+        run: pnpm prettier --check .
 
       - name: Check Lint
         run: pnpm eslint

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -9,9 +9,6 @@ pre-commit:
         - pnpm-lock.yaml
         - pnpm-workspace.yaml
 
-    - name: fix formatting
-      run: pnpm prettier --write --ignore-unknown {staged_files}
-
     - name: check types
       run: pnpm tsc
       glob:
@@ -19,6 +16,9 @@ pre-commit:
         - .npmrc
         - pnpm-lock.yaml
         - tsconfig.json
+
+    - name: fix formatting
+      run: pnpm prettier --write --ignore-unknown {staged_files}
 
     - name: fix lint
       run: pnpm eslint --no-warn-ignored --fix {staged_files}


### PR DESCRIPTION
This pull request resolves #647 by reordering the steps for checking the project in the CI workflow and pre-commit hook. The steps are now ordered so that type checks are performed before formatting and linting.