### PR TITLE
Remove Glob Pattern for Filtering Lefthook Jobs

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -8,10 +8,10 @@ pre-commit:
       run: pnpm tsc
 
     - name: fix formatting
-      run: pnpm prettier --write --ignore-unknown {staged_files}
+      run: pnpm prettier --write .
 
     - name: fix lint
-      run: pnpm eslint --no-warn-ignored --fix {staged_files}
+      run: pnpm eslint --fix
 
     - name: check documentation
       run: pnpm typedoc --emit none

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -3,19 +3,9 @@ pre-commit:
   jobs:
     - name: install dependencies
       run: pnpm install
-      glob:
-        - .npmrc
-        - package.json
-        - pnpm-lock.yaml
-        - pnpm-workspace.yaml
 
     - name: check types
       run: pnpm tsc
-      glob:
-        - "*.ts"
-        - .npmrc
-        - pnpm-lock.yaml
-        - tsconfig.json
 
     - name: fix formatting
       run: pnpm prettier --write --ignore-unknown {staged_files}
@@ -25,25 +15,9 @@ pre-commit:
 
     - name: check documentation
       run: pnpm typedoc --emit none
-      glob:
-        - src/*.ts
-        - .npmrc
-        - pnpm-lock.yaml
-        - typedoc.json
-      exclude:
-        - src/*.test.ts
 
     - name: build action
       run: pnpm rollup -c
-      glob:
-        - dist/*
-        - src/*.ts
-        - .npmrc
-        - pnpm-lock.yaml
-        - tsconfig.json
-        - rollup.config.js
-      exclude:
-        - src/*.test.ts
 
     - name: check diff
       run: git diff --exit-code dist pnpm-lock.yaml {staged_files}


### PR DESCRIPTION
This pull request resolves #649 by removing the glob pattern used to filter Lefthook jobs. It also modifies jobs to process all files.