### PR TITLE
Add Prettier Plugin for Organizing Imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .*
 !.git*
 !.npmrc
-!.prettierignore
+!.prettier*
 
 dist/lib.*
 docs/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-organize-imports"]
+}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint": "^9.30.0",
     "jiti": "^2.4.2",
     "prettier": "^3.6.2",
+    "prettier-plugin-organize-imports": "^4.2.0",
     "rollup": "^4.39.0",
     "rollup-plugin-ts": "^3.4.5",
     "typedoc": "^0.28.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      prettier-plugin-organize-imports:
+        specifier: ^4.2.0
+        version: 4.2.0(prettier@3.6.2)(typescript@5.8.3)
       rollup:
         specifier: ^4.39.0
         version: 4.39.0
@@ -1321,6 +1324,16 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-organize-imports@4.2.0:
+    resolution: {integrity: sha512-Zdy27UhlmyvATZi67BTnLcKTo8fm6Oik59Sz6H64PgZJVs6NJpPD1mT240mmJn62c98/QaL+r3kx9Q3gRpDajg==}
+    peerDependencies:
+      prettier: '>=2.0'
+      typescript: '>=2.9'
+      vue-tsc: ^2.1.0 || 3
+    peerDependenciesMeta:
+      vue-tsc:
+        optional: true
 
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
@@ -2839,6 +2852,11 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-organize-imports@4.2.0(prettier@3.6.2)(typescript@5.8.3):
+    dependencies:
+      prettier: 3.6.2
+      typescript: 5.8.3
 
   prettier@3.6.2: {}
 

--- a/src/pipx/cache.ts
+++ b/src/pipx/cache.ts
@@ -1,7 +1,7 @@
 import { restoreCache, saveCache } from "cache-action";
 import { getErrorMessage } from "catched-error-message";
-import { addPipxPackagePath, getPipxEnvironment } from "./environment.js";
 import path from "path";
+import { addPipxPackagePath, getPipxEnvironment } from "./environment.js";
 import { parsePipxPackage } from "./utils.js";
 
 export const pipxPackageCacheVersion = "pipx-install-action-2.0.0";


### PR DESCRIPTION
This pull request resolves #657 by adding [prettier-plugin-organize-imports](https://www.npmjs.com/package/prettier-plugin-organize-imports) to this project. This change also fixes formatting by organizing imports according to the plugin's rules.