### PR TITLE
Bump Node to version 24.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "^24.16.0",
+      "version": "^24.17.0",
       "onFail": "download"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         specifier: ^2.6.1
         version: 2.6.1
       node:
-        specifier: runtime:^24.16.0
+        specifier: runtime:^24.17.0
         version: runtime:24.17.0
       prettier:
         specifier: ^3.8.3


### PR DESCRIPTION
This pull request bumps Node.js to version [24.17.0](https://github.com/nodejs/node/releases/tag/v24.17.0).