### PR TITLE
Bump pnpm to version 11.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,5 @@
       "onFail": "download"
     }
   },
-  "packageManager": "pnpm@11.9.0"
+  "packageManager": "pnpm@11.15.1"
 }


### PR DESCRIPTION
This pull request bumps pnpm to version [11.15.1](https://github.com/pnpm/pnpm/releases/tag/v11.15.1).